### PR TITLE
WIP: propagation scopes

### DIFF
--- a/modules/core/src/main/scala/Span.scala
+++ b/modules/core/src/main/scala/Span.scala
@@ -10,7 +10,7 @@ import cats.effect.Resource
 trait Span[F[_]] {
 
   /** Put a sequence of fields into this span. */
-  def put(fields: (String, TraceValue)*): F[Unit]
+  def put(propagation: Propagation, fields: (String, TraceValue)*): F[Unit]
 
   /**
    * The kernel for this span, which can be sent as headers to remote systems, which can then
@@ -20,5 +20,20 @@ trait Span[F[_]] {
 
   /** Resource that yields a child span with the given name. */
   def span(name: String): Resource[F, Span[F]]
+
+}
+
+
+sealed trait Propagation extends Product with Serializable
+object Propagation {
+
+  /** Fields will not be propagated to child spans. */
+  case object None     extends Propagation
+
+  /** Fields will be propagated to child spans, but will not cross network boundaries. */
+  case object Local    extends Propagation
+
+  /** Fields will be propagated to child spans, and across network boundaries. */
+  case object Extended extends Propagation
 
 }

--- a/modules/examples/src/main/scala/Example.scala
+++ b/modules/examples/src/main/scala/Example.scala
@@ -13,7 +13,7 @@ import skunk._
 import skunk.codec.all._
 import skunk.implicits._
 import natchez.jaeger.Jaeger
-import io.jaegertracing.Configuration._
+import io.jaegertracing.Configuration.{ SamplerConfiguration, ReporterConfiguration }
 
 object Main extends IOApp {
 
@@ -29,7 +29,7 @@ object Main extends IOApp {
     Trace[F].span("names") {
       for {
         ss <- s.execute(sql"select name from country where population < 200000".query(varchar))
-        _  <- Trace[F].put("rows-count" -> ss.length)
+        _  <- Trace[F].put(Propagation.None, "rows-count" -> ss.length)
       } yield ss
     }
 
@@ -44,7 +44,7 @@ object Main extends IOApp {
         Trace[F].span("try-again") {
           for {
             _  <- names(s)
-            _  <- Trace[F].put("in-between" -> "yay!")
+            _  <- Trace[F].put(Propagation.None, "in-between" -> "yay!")
             _  <- names(s)
             m  <- Trace[F].kernel
             _  <- Sync[F].delay(m.toHeaders.foreach(println))
@@ -76,7 +76,7 @@ object Main extends IOApp {
   //         .withCollectorProtocol("<your collector protocol>")
   //         .withCollectorPort(<your collector port>)
   //         .build()
-  //       
+  //
   //       new JRETracer(options)
   //     }
   //   }

--- a/modules/jaeger/src/main/scala/JaegerSpan.scala
+++ b/modules/jaeger/src/main/scala/JaegerSpan.scala
@@ -30,7 +30,8 @@ private[jaeger] final case class JaegerSpan[F[_]: Sync](
       Kernel(m.asScala.toMap)
     }
 
-  def put(fields: (String, TraceValue)*): F[Unit] =
+  // TODO: don't ignore propagation
+  def put(propagation: Propagation, fields: (String, TraceValue)*): F[Unit] =
     fields.toList.traverse_ {
       case (k, StringValue(v))  => Sync[F].delay(span.setTag(k, v))
       case (k, NumberValue(v))  => Sync[F].delay(span.setTag(k, v))

--- a/modules/lightstep/src/main/scala/LightstepSpan.scala
+++ b/modules/lightstep/src/main/scala/LightstepSpan.scala
@@ -16,7 +16,7 @@ private[lightstep] final case class LightstepSpan[F[_]: Sync](
   tracer: ot.Tracer,
   span: ot.Span
 ) extends Span[F] {
-  
+
   import TraceValue._
 
   override def kernel: F[Kernel] =
@@ -26,7 +26,8 @@ private[lightstep] final case class LightstepSpan[F[_]: Sync](
       Kernel(m.asScala.toMap)
     }
 
-  override def put(fields: (String, TraceValue)*): F[Unit] =
+  // TODO: don't ignore propagation
+  override def put(propagation: Propagation, fields: (String, TraceValue)*): F[Unit] =
     fields.toList.traverse_ {
       case (k, StringValue(v))  => Sync[F].delay(span.setTag(k, v))
       case (k, NumberValue(v))  => Sync[F].delay(span.setTag(k, v))

--- a/modules/opencensus/src/main/scala/OpenCensusSpan.scala
+++ b/modules/opencensus/src/main/scala/OpenCensusSpan.scala
@@ -19,7 +19,8 @@ private[opencensus] final case class OpenCensusSpan[F[_]: Sync](
     extends Span[F] {
   import OpenCensusSpan._
 
-  override def put(fields: (String, TraceValue)*): F[Unit] =
+  // TODO: don't ignore propagation
+  override def put(propagation: Propagation, fields: (String, TraceValue)*): F[Unit] =
     fields.toList.traverse_ {
       case (k, StringValue(v)) =>
         Sync[F].delay(


### PR DESCRIPTION
This updates `put` to take a `Propagation` value that explains how the fields should be propagated to child spans. Resolves #17 

Value | Meaning
-|-
`Propagation.None`|  fields will not be propagated to child spans
`Propagation.Local`| fields will be propagated to child spans, but will not cross network boundaries
`Propagation.Extended` | fields will be propagated to child spans, and across network boundaries

Partially implemented for Honeycomb. Parameter currently ignored for other back ends.

