### PR TITLE
Expose current span + ability to run in span, add fs2 module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -121,8 +121,8 @@ lazy val natchez = project
     crossScalaVersions := Nil,
     publish / skip     := true
   )
-  .dependsOn(coreJS, coreJVM, jaeger, honeycomb, opencensus, opentracing, datadog, lightstep, lightstepGrpc, lightstepHttp, logJS, logJVM, mtlJS, mtlJVM, noop, mock, newrelic, logOdin, examples)
-  .aggregate(coreJS, coreJVM, jaeger, honeycomb, opencensus, opentracing, datadog, lightstep, lightstepGrpc, lightstepHttp, logJS, logJVM, mtlJS, mtlJVM, noop, mock, newrelic, logOdin, examples)
+  .dependsOn(coreJS, coreJVM, jaeger, honeycomb, opencensus, opentracing, datadog, lightstep, lightstepGrpc, lightstepHttp, logJS, logJVM, mtlJS, mtlJVM, fs2JS, fs2JVM, noop, mock, newrelic, logOdin, examples)
+  .aggregate(coreJS, coreJVM, jaeger, honeycomb, opencensus, opentracing, datadog, lightstep, lightstepGrpc, lightstepHttp, logJS, logJVM, mtlJS, mtlJVM, fs2JS, fs2JVM, noop, mock, newrelic, logOdin, examples)
 
 lazy val core = crossProject(JSPlatform, JVMPlatform)
   .in(file("modules/core"))
@@ -351,7 +351,7 @@ lazy val mock = project
 
 lazy val examples = project
   .in(file("modules/examples"))
-  .dependsOn(coreJVM, jaeger, honeycomb, lightstepHttp, datadog, logJVM, newrelic, logOdin)
+  .dependsOn(coreJVM, fs2JVM, jaeger, honeycomb, lightstepHttp, datadog, logJVM, newrelic, logOdin)
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(
@@ -366,6 +366,27 @@ lazy val examples = project
       "is.cir"            %% "ciris"          % "1.2.1"
     ).filterNot(_ => scalaVersion.value.startsWith("3."))
   )
+
+lazy val fs2 = crossProject(JSPlatform, JVMPlatform)
+  .in(file("modules/fs2"))
+  .enablePlugins(AutomateHeaderPlugin)
+  .settings(commonSettings)
+  .settings(
+    name        := "natchez-fs2",
+    description := "fs2 bindings for Natchez.",
+    libraryDependencies ++= Seq(
+      "co.fs2"            %%% "fs2-core"       % "2.5.5"
+    )
+  )
+
+lazy val fs2JVM = fs2.jvm.dependsOn(coreJVM)
+lazy val fs2JS = fs2.js.dependsOn(coreJS)
+  .settings(
+    Test / scalaJSStage := FastOptStage,
+    jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv(),
+    scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)),
+  )
+
 
 lazy val logOdin = project
   .in(file("modules/log-odin"))

--- a/modules/core/shared/src/main/scala/NoopSpan.scala
+++ b/modules/core/shared/src/main/scala/NoopSpan.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2019-2020 by Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package natchez
+
+import cats._
+import cats.effect.Resource
+import cats.syntax.all._
+
+import java.net.URI
+
+final case class NoopSpan[F[_]: Applicative]() extends Span[F] {
+
+  override def put(fields: (String, TraceValue)*): F[Unit] =
+    Applicative[F].unit
+
+  override def kernel: F[Kernel] =
+    Applicative[F].pure(Kernel(Map.empty))
+
+  override def span(name: String): Resource[F, Span[F]] =
+    Resource.eval(NoopSpan[F]().pure[F])
+
+  // TODO
+  def traceId: F[Option[String]] = none.pure[F]
+
+  def spanId: F[Option[String]] = none.pure[F]
+
+  def traceUri: F[Option[URI]] = none.pure[F]
+
+}

--- a/modules/examples/src/main/scala-2/Example.scala
+++ b/modules/examples/src/main/scala-2/Example.scala
@@ -15,7 +15,7 @@ import java.net.URI
 
 object Main extends IOApp {
 
-  def runF[F[_]: Sync: Trace: Parallel: Timer]: F[Unit] =
+  def runF[F[_]: Concurrent: Trace: Parallel: Timer]: F[Unit] =
     Trace[F].span("Sort some stuff!") {
       for {
         as <- Sync[F].delay(List.fill(10)(Random.nextInt(1000)))

--- a/modules/examples/src/main/scala-2/GlobalTracerExample.scala
+++ b/modules/examples/src/main/scala-2/GlobalTracerExample.scala
@@ -16,7 +16,7 @@ import java.net.URI
 
 object GlobalTracerMain extends IOApp {
 
-  def runF[F[_]: Sync: Trace: Parallel: Timer]: F[Unit] =
+  def runF[F[_]: Concurrent: Trace: Parallel: Timer]: F[Unit] =
     Trace[F].span("Sort some stuff!") {
       for {
         as <- Sync[F].delay(List.fill(10)(Random.nextInt(1000)))

--- a/modules/examples/src/main/scala-2/Sort.scala
+++ b/modules/examples/src/main/scala-2/Sort.scala
@@ -5,24 +5,60 @@
 package example
 
 import cats._
-import cats.effect.Timer
+import cats.effect.concurrent.Deferred
+import cats.effect.{Concurrent, Timer}
 import cats.syntax.all._
-import natchez.Trace
+import natchez.{Span, Trace}
+import natchez.fs2._
+
 import scala.concurrent.duration._
+import _root_.fs2._
+import _root_.fs2.concurrent.Queue
 
 object Sort {
 
   // Intentionally slow parallel quicksort, to demonstrate branching. If we run too quickly it seems
   // to break Jaeger with "skipping clock skew adjustment" so let's pause a bit each time.
-  def qsort[F[_]: Monad: Parallel: Trace: Timer, A: Order](as: List[A]): F[List[A]] =
-    Trace[F].span(as.mkString(",")) {
-      Timer[F].sleep(10.milli) *> {
-          as match {
-          case Nil    => Monad[F].pure(Nil)
-          case h :: t =>
-            val (a, b) = t.partition(_ <= h)
-            (qsort[F, A](a), qsort[F, A](b)).parMapN(_ ++ List(h) ++ _)
+  def qsort[F[_] : Concurrent : Parallel : Timer, A: Order](as: List[A])(implicit trace: Trace[F]): F[List[A]] = {
+    case class ConcatRequest(left: List[A], mid: A, right: List[A], span: Span[trace.Sp], cb: List[A] => F[Unit])
+
+    Stream.eval(Queue.unbounded[F, ConcatRequest]).flatMap { q =>
+
+      def qsort(as: List[A]): F[List[A]] =
+        Trace[F].span(s"sort ${as.mkString(",")}") {
+          Timer[F].sleep(10.milli) *> {
+            as match {
+              case Nil => Monad[F].pure(Nil)
+              case h :: t =>
+                val (a, b) = t.partition(_ <= h)
+                (qsort(a), qsort(b)).parTupled.flatMap { case (l, r) =>
+                  Deferred[F, List[A]].flatMap { deferred =>
+                    trace.span("request concat") {
+                      trace.current.flatMap { span =>
+                        q.enqueue1(ConcatRequest(l, h, r, span, deferred.complete))
+                      } *> deferred.get
+                    }
+                  }
+                }
+            }
+          }
+        }
+
+      Stream.eval(qsort(as)).concurrently {
+        Trace[Stream[F, *]].span("process concat reqeusts from queue") {
+          q.dequeue.evalMap { case ConcatRequest(left, mid, right, span, cb) =>
+            trace.liftSp(span.spanId).flatMap { spanId =>
+              Trace[F].span(s"Asynchronously process ConcatRequest (for spanId $spanId)") {
+                Trace[F].runWith(span) {
+                  trace.span(s"concat ${left.mkString(",")} + $mid + ${right.mkString(",")}") {
+                    cb(left ++ List(mid) ++ right)
+                  }
+                }
+              }
+            }
+          }
         }
       }
-    }
+    }.compile.lastOrError
+  }
 }

--- a/modules/fs2/shared/src/main/scala/package.scala
+++ b/modules/fs2/shared/src/main/scala/package.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2019-2020 by Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package natchez
+
+import cats.effect.Concurrent
+import cats.~>
+import _root_.fs2.Stream
+
+package object fs2 {
+  implicit def natchezFs2TraceForStream[F[_]: Concurrent](implicit t: Trace[F]): Trace.Aux[Stream[F, *], t.Sp] =
+    new Trace.Lifted[F, Stream[F, *], t.Sp](t) {
+
+      def lift[A](fa: F[A]): Stream[F, A] = Stream.eval(fa)
+
+      override def span[A](name: String)(k: Stream[F, A]): Stream[F, A] =
+        current.flatMap { span =>
+          Stream.resource(span.span(name).mapK(trace.liftSpK)).flatMap { span =>
+            runWith(span)(k)
+          }
+        }
+
+      override def runWith[A](span: Span[Sp])(k: Stream[F, A]): Stream[F, A] =
+        k.translateInterruptible(new (~>[F, F]) {
+          def apply[A0](fa: F[A0]): F[A0] = trace.runWith(span)(fa)
+        })
+  }
+}

--- a/modules/mtl/shared/src/main/scala/package.scala
+++ b/modules/mtl/shared/src/main/scala/package.scala
@@ -11,6 +11,6 @@ package object mtl {
   implicit def natchezMtlTraceForLocal[F[_]](
     implicit ev: Local[F, Span[F]],
              eb: Bracket[F, Throwable],
-  ): Trace[F] =
+  ): Trace.Aux[F, F] =
     new LocalTrace(ev)
 }

--- a/modules/noop/src/main/scala/NoopTrace.scala
+++ b/modules/noop/src/main/scala/NoopTrace.scala
@@ -11,6 +11,10 @@ import java.net.URI
 
 final case class NoopTrace[F[_]: Applicative]() extends Trace[F] {
 
+  type Sp[A] = F[A]
+
+  override def liftSp[A](spa: F[A]): F[A] = spa
+
   override def put(fields: (String, TraceValue)*): F[Unit] =
     Applicative[F].unit
 
@@ -19,6 +23,10 @@ final case class NoopTrace[F[_]: Applicative]() extends Trace[F] {
 
   override def span[A](name: String)(k: F[A]): F[A] =
     k
+
+  override def current: F[Span[F]] = NoopSpan[F]().pure[F].widen
+
+  override def runWith[A](span: Span[F])(k: F[A]): F[A] = k
 
   def traceId: F[Option[String]] =
     none.pure[F]


### PR DESCRIPTION
This requires `Trace` to expose a type member representing the type of `Span` it uses, which is a bit nasty, but it allows some nice extra functionality.

The sorting example is modified to show propagation of spans outside of monadic scope.

I'm closing #344, as this achieves the same thing in a more general way.