### PR TITLE
fix(ddspan): rm error propagation from child to parent

### DIFF
--- a/modules/datadog/src/main/scala/DDSpan.scala
+++ b/modules/datadog/src/main/scala/DDSpan.scala
@@ -101,17 +101,7 @@ final case class DDSpan[F[_]: Sync](
       DDTags.ERROR_MSG -> err.getMessage,
       DDTags.ERROR_TYPE -> err.getClass.getSimpleName,
       DDTags.ERROR_STACK -> err.getStackTrace.mkString
-    ) >> {
-      // Set error on root span
-      span match {
-        case ms: MutableSpan =>
-          Sync[F].delay {
-            val localRootSpan = ms.getLocalRootSpan
-            localRootSpan.setError(true)
-          }.void
-        case _ => Sync[F].unit
-      }
-    } >>
+    ) >>
       Sync[F].delay {
         span.log(
           (Map(


### PR DESCRIPTION
Error status of span is not propagaed from child to parent in other Span impl. There seem to be no proper reason to also do it for Data dog spans

Solves https://github.com/tpolecat/natchez/issues/734
