### PR TITLE
Throwable getMessage can return null

### DIFF
--- a/modules/log/shared/src/main/scala/LogSpan.scala
+++ b/modules/log/shared/src/main/scala/LogSpan.scala
@@ -75,7 +75,7 @@ private[log] final case class LogSpan[F[_]: Sync: Logger](
     putAny(
       "exit.case" -> "error".asJson,
       "exit.error.class" -> err.getClass.getName.asJson,
-      "exit.error.message" -> err.toString.asJson, // toString handles null message
+      "exit.error.message" -> Option(err.getMessage).map(_.asJson).getOrElse(Json.Null),
       "exit.error.stackTrace" -> err.getStackTrace.map(_.toString).asJson
     ) *> put(fields: _*)
 

--- a/modules/log/shared/src/main/scala/LogSpan.scala
+++ b/modules/log/shared/src/main/scala/LogSpan.scala
@@ -75,7 +75,7 @@ private[log] final case class LogSpan[F[_]: Sync: Logger](
     putAny(
       "exit.case" -> "error".asJson,
       "exit.error.class" -> err.getClass.getName.asJson,
-      "exit.error.message" -> err.getMessage.asJson,
+      "exit.error.message" -> err.toString.asJson, // toString handles null message
       "exit.error.stackTrace" -> err.getStackTrace.map(_.toString).asJson
     ) *> put(fields: _*)
 

--- a/modules/log/shared/src/test/scala/LogSuite.scala
+++ b/modules/log/shared/src/test/scala/LogSuite.scala
@@ -105,7 +105,7 @@ class LogSuite extends CatsEffectSuite {
                       |  ],
                       |  "exit.case" : "succeeded",
                       |  "exit.error.class" : "java.lang.RuntimeException",
-                      |  "exit.error.message" : "java.lang.RuntimeException: oops",
+                      |  "exit.error.message" : "oops",
                       |  "children" : [
                       |  ]
                       |}
@@ -118,7 +118,7 @@ class LogSuite extends CatsEffectSuite {
                    |  ],
                    |  "exit.case" : "succeeded",
                    |  "exit.error.class" : "java.lang.RuntimeException",
-                   |  "exit.error.message" : "java.lang.RuntimeException",
+                   |  "exit.error.message" : null,
                    |  "children" : [
                    |  ]
                    |}


### PR DESCRIPTION
We've had instances where a throwable with no error message would break the logger.

For instance, if you call `asJson` on a `null` it does:

```scala
//> using scala "2.13.10"
//> using lib "io.circe::circe-core:0.14.5"

import io.circe._
import io.circe.syntax._

case class CrappyError(msg: String) extends RuntimeException(msg)
object MyTest extends App {
  val err = CrappyError(null)
  println(err.getMessage.asJson)
}
```

results in:

```scala
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "String.length()" because "value" is null
        at io.circe.Printer$PrintingFolder.onString(Printer.scala:319)
        at io.circe.Printer$PrintingFolder.onString(Printer.scala:302)
        at io.circe.Json$JString.foldWith(Json.scala:369)
        at io.circe.Printer.unsafePrintToAppendable(Printer.scala:229)
        at io.circe.Printer.print(Printer.scala:197)
        at io.circe.Json.spaces2(Json.scala:127)
        at io.circe.Json.toString(Json.scala:220)
        at java.base/java.lang.String.valueOf(String.java:4215)
        at java.base/java.io.PrintStream.println(PrintStream.java:1047)
        at scala.Console$.println(Console.scala:268)
        at scala.Predef$.println(Predef.scala:427)
```