### PR TITLE
Fix URL to site

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@
 
 Natchez is distributed tracing library for Scala.
 
-Please proceed to the [microsite](http://tpolecat.github.io/natchez/) for more information.
+Please proceed to the [microsite](https://typelevel.org/natchez/) for more information.
 


### PR DESCRIPTION
Looks like [tpolecat.org/natchez/](http://tpolecat.org/natchez/) doesn't work, so I changed it to [typelevel.org/natchez/](https://typelevel.org/natchez/) instead.