### PR TITLE
Add 'spanId' to Trace interface

### DIFF
--- a/modules/core/shared/src/main/scala/Trace.scala
+++ b/modules/core/shared/src/main/scala/Trace.scala
@@ -104,7 +104,7 @@ object Trace {
         override def traceId: IO[Option[String]] =
           local.get.flatMap(_.traceId)
 
-        override def spanId: IO[Option[String]] =
+        override def spanId(implicit F: Applicative[IO]): IO[Option[String]] =
           local.get.flatMap(_.spanId)
 
         override def traceUri: IO[Option[URI]] =
@@ -134,7 +134,8 @@ object Trace {
           Resource.pure(FunctionK.id)
         override def span[A](name: String, options: Span.Options)(k: F[A]): F[A] = k
         override def traceId: F[Option[String]] = none.pure[F]
-        override def spanId: F[Option[String]] = none.pure[F]
+        override def spanId(implicit A: Applicative[F]): F[Option[String]] =
+          A.pure(None)
         override def traceUri: F[Option[URI]] = none.pure[F]
       }
   }
@@ -235,7 +236,9 @@ object Trace {
         override def traceId: Kleisli[F, E, Option[String]] =
           Kleisli(e => f(e).traceId)
 
-        override def spanId: Kleisli[F, E, Option[String]] =
+        override def spanId(implicit
+            F: Applicative[Kleisli[F, E, *]]
+        ): Kleisli[F, E, Option[String]] =
           Kleisli(e => f(e).spanId)
 
         override def traceUri: Kleisli[F, E, Option[URI]] =
@@ -245,7 +248,9 @@ object Trace {
     override def traceId: Kleisli[F, Span[F], Option[String]] =
       Kleisli(_.traceId)
 
-    override def spanId: Kleisli[F, Span[F], Option[String]] =
+    override def spanId(implicit
+        F: Applicative[Kleisli[F, Span[F], *]]
+    ): Kleisli[F, Span[F], Option[String]] =
       Kleisli(_.spanId)
 
     override def traceUri: Kleisli[F, Span[F], Option[URI]] =
@@ -293,7 +298,9 @@ object Trace {
       override def traceId: Kleisli[F, E, Option[String]] =
         Kleisli.liftF(trace.traceId)
 
-      override def spanId: Kleisli[F, E, Option[String]] =
+      override def spanId(implicit
+          F: Applicative[Kleisli[F, E, *]]
+      ): Kleisli[F, E, Option[String]] =
         Kleisli.liftF(trace.spanId)
 
       override def traceUri: Kleisli[F, E, Option[URI]] =
@@ -343,7 +350,9 @@ object Trace {
       override def traceId: StateT[F, S, Option[String]] =
         StateT.liftF(trace.traceId)
 
-      override def spanId: StateT[F, S, Option[String]] =
+      override def spanId(implicit
+          F: Applicative[StateT[F, S, *]]
+      ): StateT[F, S, Option[String]] =
         StateT.liftF(trace.spanId)
 
       override def traceUri: StateT[F, S, Option[URI]] =
@@ -394,7 +403,9 @@ object Trace {
       override def traceId: EitherT[F, E, Option[String]] =
         EitherT.liftF(trace.traceId)
 
-      override def spanId: EitherT[F, E, Option[String]] =
+      override def spanId(implicit
+          F: Applicative[EitherT[F, E, *]]
+      ): EitherT[F, E, Option[String]] =
         EitherT.liftF(trace.spanId)
 
       override def traceUri: EitherT[F, E, Option[URI]] =
@@ -441,7 +452,9 @@ object Trace {
       override def traceId: OptionT[F, Option[String]] =
         OptionT.liftF(trace.traceId)
 
-      override def spanId: OptionT[F, Option[String]] =
+      override def spanId(implicit
+          F: Applicative[OptionT[F, *]]
+      ): OptionT[F, Option[String]] =
         OptionT.liftF(trace.spanId)
 
       override def traceUri: OptionT[F, Option[URI]] =
@@ -495,7 +508,9 @@ object Trace {
       override def traceId: Nested[F, G, Option[String]] =
         trace.traceId.map(_.pure[G]).nested
 
-      override def spanId: Nested[F, G, Option[String]] =
+      override def spanId(implicit
+          F: Applicative[Nested[F, G, *]]
+      ): Nested[F, G, Option[String]] =
         trace.spanId.map(_.pure[G]).nested
 
       override def traceUri: Nested[F, G, Option[URI]] =
@@ -547,7 +562,9 @@ object Trace {
       override def traceId: Resource[F, Option[String]] =
         Resource.eval(trace.traceId)
 
-      override def spanId: Resource[F, Option[String]] =
+      override def spanId(implicit
+          F: Applicative[Resource[F, *]]
+      ): Resource[F, Option[String]] =
         Resource.eval(trace.spanId)
 
       override def traceUri: Resource[F, Option[URI]] =
@@ -593,7 +610,9 @@ object Trace {
       override def traceId: Stream[F, Option[String]] =
         Stream.eval(trace.traceId)
 
-      override def spanId: Stream[F, Option[String]] =
+      override def spanId(implicit
+          F: Applicative[Stream[F, *]]
+      ): Stream[F, Option[String]] =
         Stream.eval(trace.spanId)
 
       override def traceUri: Stream[F, Option[URI]] =

--- a/modules/core/shared/src/main/scala/Trace.scala
+++ b/modules/core/shared/src/main/scala/Trace.scala
@@ -52,7 +52,7 @@ trait Trace[F[_]] {
   /** A unique ID for this span, if available. This can be useful to include in error messages for
     * example, so you can quickly find the associated trace.
     */
-  def spanId: F[Option[String]]
+  def spanId(implicit F: Applicative[F]): F[Option[String]] = F.pure(None)
 
   /** A unique URI for this trace, if available. This can be useful to include in error messages for
     * example, so you can quickly find the associated trace.

--- a/modules/core/shared/src/main/scala/Trace.scala
+++ b/modules/core/shared/src/main/scala/Trace.scala
@@ -49,6 +49,11 @@ trait Trace[F[_]] {
     */
   def traceId: F[Option[String]]
 
+  /** A unique ID for this span, if available. This can be useful to include in error messages for
+    * example, so you can quickly find the associated trace.
+    */
+  def spanId: F[Option[String]]
+
   /** A unique URI for this trace, if available. This can be useful to include in error messages for
     * example, so you can quickly find the associated trace.
     */
@@ -99,6 +104,9 @@ object Trace {
         override def traceId: IO[Option[String]] =
           local.get.flatMap(_.traceId)
 
+        override def spanId: IO[Option[String]] =
+          local.get.flatMap(_.spanId)
+
         override def traceUri: IO[Option[URI]] =
           local.get.flatMap(_.traceUri)
       }
@@ -126,6 +134,7 @@ object Trace {
           Resource.pure(FunctionK.id)
         override def span[A](name: String, options: Span.Options)(k: F[A]): F[A] = k
         override def traceId: F[Option[String]] = none.pure[F]
+        override def spanId: F[Option[String]] = none.pure[F]
         override def traceUri: F[Option[URI]] = none.pure[F]
       }
   }
@@ -226,12 +235,18 @@ object Trace {
         override def traceId: Kleisli[F, E, Option[String]] =
           Kleisli(e => f(e).traceId)
 
+        override def spanId: Kleisli[F, E, Option[String]] =
+          Kleisli(e => f(e).spanId)
+
         override def traceUri: Kleisli[F, E, Option[URI]] =
           Kleisli(e => f(e).traceUri)
       }
 
     override def traceId: Kleisli[F, Span[F], Option[String]] =
       Kleisli(_.traceId)
+
+    override def spanId: Kleisli[F, Span[F], Option[String]] =
+      Kleisli(_.spanId)
 
     override def traceUri: Kleisli[F, Span[F], Option[URI]] =
       Kleisli(_.traceUri)
@@ -277,6 +292,9 @@ object Trace {
 
       override def traceId: Kleisli[F, E, Option[String]] =
         Kleisli.liftF(trace.traceId)
+
+      override def spanId: Kleisli[F, E, Option[String]] =
+        Kleisli.liftF(trace.spanId)
 
       override def traceUri: Kleisli[F, E, Option[URI]] =
         Kleisli.liftF(trace.traceUri)
@@ -324,6 +342,9 @@ object Trace {
 
       override def traceId: StateT[F, S, Option[String]] =
         StateT.liftF(trace.traceId)
+
+      override def spanId: StateT[F, S, Option[String]] =
+        StateT.liftF(trace.spanId)
 
       override def traceUri: StateT[F, S, Option[URI]] =
         StateT.liftF(trace.traceUri)
@@ -373,6 +394,9 @@ object Trace {
       override def traceId: EitherT[F, E, Option[String]] =
         EitherT.liftF(trace.traceId)
 
+      override def spanId: EitherT[F, E, Option[String]] =
+        EitherT.liftF(trace.spanId)
+
       override def traceUri: EitherT[F, E, Option[URI]] =
         EitherT.liftF(trace.traceUri)
     }
@@ -416,6 +440,9 @@ object Trace {
 
       override def traceId: OptionT[F, Option[String]] =
         OptionT.liftF(trace.traceId)
+
+      override def spanId: OptionT[F, Option[String]] =
+        OptionT.liftF(trace.spanId)
 
       override def traceUri: OptionT[F, Option[URI]] =
         OptionT.liftF(trace.traceUri)
@@ -468,6 +495,9 @@ object Trace {
       override def traceId: Nested[F, G, Option[String]] =
         trace.traceId.map(_.pure[G]).nested
 
+      override def spanId: Nested[F, G, Option[String]] =
+        trace.spanId.map(_.pure[G]).nested
+
       override def traceUri: Nested[F, G, Option[URI]] =
         trace.traceUri.map(_.pure[G]).nested
     }
@@ -517,6 +547,9 @@ object Trace {
       override def traceId: Resource[F, Option[String]] =
         Resource.eval(trace.traceId)
 
+      override def spanId: Resource[F, Option[String]] =
+        Resource.eval(trace.spanId)
+
       override def traceUri: Resource[F, Option[URI]] =
         Resource.eval(trace.traceUri)
     }
@@ -559,6 +592,9 @@ object Trace {
 
       override def traceId: Stream[F, Option[String]] =
         Stream.eval(trace.traceId)
+
+      override def spanId: Stream[F, Option[String]] =
+        Stream.eval(trace.spanId)
 
       override def traceUri: Stream[F, Option[URI]] =
         Stream.eval(trace.traceUri)

--- a/modules/mtl/shared/src/main/scala/LocalTrace.scala
+++ b/modules/mtl/shared/src/main/scala/LocalTrace.scala
@@ -54,6 +54,9 @@ private[mtl] class LocalTrace[F[_]](local: Local[F, Span[F]])(implicit
   override def traceId: F[Option[String]] =
     local.ask.flatMap(_.traceId)
 
+  override def spanId: F[Option[String]] =
+    local.ask.flatMap(_.spanId)
+
   override def traceUri: F[Option[URI]] =
     local.ask.flatMap(_.traceUri)
 }

--- a/modules/mtl/shared/src/main/scala/LocalTrace.scala
+++ b/modules/mtl/shared/src/main/scala/LocalTrace.scala
@@ -12,6 +12,7 @@ import cats.effect.MonadCancel
 import cats.effect.Resource
 import cats.syntax.all._
 import java.net.URI
+import cats.Applicative
 
 private[mtl] class LocalTrace[F[_]](local: Local[F, Span[F]])(implicit
     ev: MonadCancel[F, Throwable]
@@ -54,7 +55,7 @@ private[mtl] class LocalTrace[F[_]](local: Local[F, Span[F]])(implicit
   override def traceId: F[Option[String]] =
     local.ask.flatMap(_.traceId)
 
-  override def spanId: F[Option[String]] =
+  override def spanId(implicit F: Applicative[F]): F[Option[String]] =
     local.ask.flatMap(_.spanId)
 
   override def traceUri: F[Option[URI]] =

--- a/modules/noop/shared/src/main/scala/NoopTrace.scala
+++ b/modules/noop/shared/src/main/scala/NoopTrace.scala
@@ -33,9 +33,12 @@ final case class NoopTrace[F[_]: Applicative]() extends Trace[F] {
   override def span[A](name: String, options: Span.Options)(k: F[A]): F[A] =
     k
 
-  def traceId: F[Option[String]] =
+  override def traceId: F[Option[String]] =
     none.pure[F]
 
-  def traceUri: F[Option[URI]] =
+  override def spanId: F[Option[String]] =
+    none.pure[F]
+
+  override def traceUri: F[Option[URI]] =
     none.pure[F]
 }

--- a/modules/noop/shared/src/main/scala/NoopTrace.scala
+++ b/modules/noop/shared/src/main/scala/NoopTrace.scala
@@ -36,8 +36,8 @@ final case class NoopTrace[F[_]: Applicative]() extends Trace[F] {
   override def traceId: F[Option[String]] =
     none.pure[F]
 
-  override def spanId: F[Option[String]] =
-    none.pure[F]
+  override def spanId(implicit A: Applicative[F]): F[Option[String]] =
+    A.pure(None)
 
   override def traceUri: F[Option[URI]] =
     none.pure[F]


### PR DESCRIPTION
Looks like `spanId` was omitted from the `Trace[F]` interface, probably by accident? According to [this section](https://typelevel.org/natchez/reference/spans.html#span-properties) of the docs, it should be accessible from the ambient spans using the `Trace` effect. 