### PR TITLE
Datadog: do not propagate error to root span

### DIFF
--- a/modules/datadog/src/main/scala/DDSpan.scala
+++ b/modules/datadog/src/main/scala/DDSpan.scala
@@ -15,7 +15,6 @@ import io.opentracing.propagation.{Format, TextMapAdapter}
 import io.opentracing.tag.Tags
 import natchez.TraceValue.{BooleanValue, NumberValue, StringValue}
 import _root_.datadog.trace.api.DDTags
-import _root_.datadog.trace.api.interceptor.MutableSpan
 import natchez.Span.Options
 import natchez.datadog.DDTracer.{addLink, addSpanKind}
 
@@ -101,17 +100,7 @@ final case class DDSpan[F[_]: Sync](
       DDTags.ERROR_MSG -> err.getMessage,
       DDTags.ERROR_TYPE -> err.getClass.getSimpleName,
       DDTags.ERROR_STACK -> err.getStackTrace.mkString
-    ) >> {
-      // Set error on root span
-      span match {
-        case ms: MutableSpan =>
-          Sync[F].delay {
-            val localRootSpan = ms.getLocalRootSpan
-            localRootSpan.setError(true)
-          }.void
-        case _ => Sync[F].unit
-      }
-    } >>
+    ) >>
       Sync[F].delay {
         span.log(
           (Map(


### PR DESCRIPTION
Fixes #734

As agreed in #734, this brings the behaviour of the Datadog backend in line with the other backends.

This PR is just a re-do of #735, fixing the unused import error