### PR TITLE
Pass span options in RootsSpan

### DIFF
--- a/modules/core/shared/src/main/scala/Span.scala
+++ b/modules/core/shared/src/main/scala/Span.scala
@@ -142,7 +142,7 @@ object Span {
 
   private class RootsSpan[F[_]: Applicative](ep: EntryPoint[F]) extends EphemeralSpan[F] {
     override def span(name: String, options: Span.Options): Resource[F, Span[F]] =
-      options.parentKernel.fold(ep.root(name))(ep.continueOrElseRoot(name, _))
+      options.parentKernel.fold(ep.root(name, options))(ep.continueOrElseRoot(name, _, options))
   }
 
   private def resolve[F[_]](span: Span[F]): Kleisli[F, Span[F], *] ~> F =


### PR DESCRIPTION
Wanted to ask if there is any reason why the `Span.Options` are not passed from `RootsSpan`? Currently `RootsSpan` is only used for `IOLocal` based implementation, but if typelevel/natchez-http4s#34 is accepted, it will be needed for both `IOLocal` and `Kleisli` to propagate options from `RootsSpan` correctly.