### PR TITLE
Remove explicit dependency on scodec-bits (pick up via fs2)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -322,8 +322,7 @@ lazy val xray = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies ++= Seq(
       "io.circe" %%% "circe-core" % "0.14.8",
       "co.fs2" %%% "fs2-io" % fs2Version,
-      "com.comcast" %%% "ip4s-core" % "3.6.0",
-      "org.scodec" %%% "scodec-bits" % "1.2.0"
+      "com.comcast" %%% "ip4s-core" % "3.6.0"
     )
   )
   .jsSettings(


### PR DESCRIPTION
Noticed we accidentally upgraded to a version of scodec-bits that was moved to native 0.5. This didn't break anything since the explicit dependency was only on the xray module, which doesn't target native. 