### PR TITLE
Add an example of Trace instance for IO

### DIFF
--- a/modules/docs/src/main/paradox/reference/trace.md
+++ b/modules/docs/src/main/paradox/reference/trace.md
@@ -82,8 +82,6 @@ This is more general than the `Kleisli` instance above and allows you to instant
 
 ## Cats-Effect 3 IO Instance
 
-Given a `Span[F]` you can construct a `Trace[IO]` for **Cats-Effect 3** (for Cats-Effect 2 you will need to use `Kleisli` or `Local` above). This uses `FiberLocal` to pass the span around.
-Given a `Span[F]` you can construct a `Trace[IO]` for **Cats-Effect 3** (for
 Given a `Span[IO]` you can construct a `Trace[IO]` for **Cats-Effect 3** (for
 Cats-Effect 2 you will need to use `Kleisli` or `Local` above). This uses
 `IOLocal` to pass the span around.
@@ -97,7 +95,6 @@ def goIO(span: Span[IO]): IO[Unit] =
   }
 ```
 
-Alternatively, a `Trace[IO]` can be constructed from an `EntryPoint`, which
 Alternatively, a `Trace[IO]` can be constructed from an `EntryPoint[IO]`, which
 takes care of creation of child spans.
 

--- a/modules/docs/src/main/paradox/reference/trace.md
+++ b/modules/docs/src/main/paradox/reference/trace.md
@@ -84,4 +84,11 @@ This is more general than the `Kleisli` instance above and allows you to instant
 
 Given a `Span[F]` you can construct a `Trace[IO]` for **Cats-Effect 3** (for Cats-Effect 2 you will need to use `Kleisli` or `Local` above). This uses `FiberLocal` to pass the span around.
 
-TODO: Example
+```scala mdoc
+import cats.effect.IO
+
+def goIO(span: Span[IO]): IO[Unit] =
+  Trace.ioTrace(span).flatMap { implicit trace =>
+    wibble[IO]("bob", 42)
+  }
+```

--- a/modules/docs/src/main/paradox/reference/trace.md
+++ b/modules/docs/src/main/paradox/reference/trace.md
@@ -82,21 +82,8 @@ This is more general than the `Kleisli` instance above and allows you to instant
 
 ## Cats-Effect 3 IO Instance
 
-Given a `Span[IO]` you can construct a `Trace[IO]` for **Cats-Effect 3** (for
-Cats-Effect 2 you will need to use `Kleisli` or `Local` above). This uses
-`IOLocal` to pass the span around.
-
-```scala mdoc
-import cats.effect.IO
-
-def goIO(span: Span[IO]): IO[Unit] =
-  Trace.ioTrace(span).flatMap { implicit trace =>
-    wibble[IO]("bob", 42)
-  }
-```
-
-Alternatively, a `Trace[IO]` can be constructed from an `EntryPoint[IO]`, which
-takes care of creation of child spans.
+Given an `EntryPoint[IO]` you can construct a `Trace[IO]` for **Cats-Effect 3**.
+This will create a root span for each requested child span.
 
 ```scala mdoc
 import cats.effect.IO
@@ -107,3 +94,17 @@ def goIO(ep: EntryPoint[IO]): IO[Unit] =
     wibble[IO]("bob", 42)
   }
 ```
+
+Alternatively, a `Trace[IO]` can be constructed from a `Span[IO]` directly.
+
+```scala mdoc
+import cats.effect.IO
+
+def goIO(span: Span[IO]): IO[Unit] =
+  Trace.ioTrace(span).flatMap { implicit trace =>
+    wibble[IO]("bob", 42)
+  }
+```
+
+Both methods use `IOLocal` to pass the span around. For Cats-Effect 2 you will
+need to use `Kleisli` or `Local` as described above.

--- a/modules/docs/src/main/paradox/reference/trace.md
+++ b/modules/docs/src/main/paradox/reference/trace.md
@@ -83,12 +83,30 @@ This is more general than the `Kleisli` instance above and allows you to instant
 ## Cats-Effect 3 IO Instance
 
 Given a `Span[F]` you can construct a `Trace[IO]` for **Cats-Effect 3** (for Cats-Effect 2 you will need to use `Kleisli` or `Local` above). This uses `FiberLocal` to pass the span around.
+Given a `Span[F]` you can construct a `Trace[IO]` for **Cats-Effect 3** (for
+Given a `Span[IO]` you can construct a `Trace[IO]` for **Cats-Effect 3** (for
+Cats-Effect 2 you will need to use `Kleisli` or `Local` above). This uses
+`IOLocal` to pass the span around.
 
 ```scala mdoc
 import cats.effect.IO
 
 def goIO(span: Span[IO]): IO[Unit] =
   Trace.ioTrace(span).flatMap { implicit trace =>
+    wibble[IO]("bob", 42)
+  }
+```
+
+Alternatively, a `Trace[IO]` can be constructed from an `EntryPoint`, which
+Alternatively, a `Trace[IO]` can be constructed from an `EntryPoint[IO]`, which
+takes care of creation of child spans.
+
+```scala mdoc
+import cats.effect.IO
+import natchez.EntryPoint
+
+def goIO(ep: EntryPoint[IO]): IO[Unit] =
+  Trace.ioTraceForEntryPoint(ep).flatMap { implicit trace =>
     wibble[IO]("bob", 42)
   }
 ```


### PR DESCRIPTION
Hello, this PR adds a simple `Trace[IO]` example to the docs.
Would that be sufficient, or should I expand this to cover anything else?