### PR TITLE
Regenerate site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+*.class
+*.log
+
+# these are moved into the doc project by the build
+modules/docs/src/main/tut/changelog.md
+modules/docs/src/main/tut/license.md
+
+# sbt specific
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+project/hydra.sbt
+
+# Scala-IDE specific
+.scala_dependencies
+.cache
+.classpath
+.project
+.worksheet/
+bin/
+.settings/
+
+# OS X
+.DS_Store
+
+# Ctags
+.tags
+
+# ENSIME
+.ensime
+.ensime_cache/
+
+# IntelliJ
+.idea/
+
+# Mill
+out/
+
+# Bloop/Metals
+.bloop/
+.metals/
+metals.sbt
+.bsp/
+
+# VS-Code
+.vscode/

--- a/backends/datadog.html
+++ b/backends/datadog.html
@@ -6,7 +6,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content='docs'/>
-<link rel="canonical" href="https://github.com/tpolecat/natchezbackends/datadog.html"/>
+<link rel="canonical" href="https://github.com/typelevel/natchezbackends/datadog.html"/>
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="../lib/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="../js/page.js"></script>
@@ -32,7 +32,7 @@
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -58,6 +58,7 @@
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -95,7 +96,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -121,6 +122,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -153,19 +155,66 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <div class="page-content row">
 <div class="small-12 large-9 column" id="docs">
 <h1><a href="#datadog" name="datadog" class="anchor"><span class="anchor-link"></span></a>Datadog</h1>
+<p>To get access to an <code>EntryPoint</code> instance for DataDog, add the following dependency.</p>
+<p>It transitively pulls in <code>&quot;com.datadoghq&quot; % &quot;dd-trace-ot&quot;</code> and <code>&quot;com.datadoghq&quot; % &quot;dd-trace-api&quot;</code>.</p><dl class="dependency"><dt>sbt</dt><dd><pre class="prettyprint"><code class="language-scala">libraryDependencies += "org.tpolecat" %% "natchez-datadog" % "0.3.7"</code></pre></dd><dt>Maven</dt><dd><pre class="prettyprint"><code class="language-xml">&lt;dependencies&gt
+  &lt;dependency&gt;
+    &lt;groupId&gt;org.tpolecat&lt;/groupId&gt;
+    &lt;artifactId&gt;natchez-datadog_2.13&lt;/artifactId&gt;
+    &lt;version&gt;0.3.7&lt;/version&gt;
+  &lt;/dependency&gt
+&lt;/dependencies&gt;</code></pre></dd><dt>Gradle</dt><dd><pre class="prettyprint"><code class="language-gradle">dependencies {
+  implementation "org.tpolecat:natchez-datadog_2.13:0.3.7"
+}</code></pre></dd></dl>
+<h2><a href="#constructing-an-entrypoint" name="constructing-an-entrypoint" class="anchor"><span class="anchor-link"></span></a>Constructing an EntryPoint</h2>
+<p>You can use <code>DDTracer.entryPoint</code> to build a DataDog tracer, register it globally, and get it as a <code>Resource[F, EntryPoint[F]]</code>. The method takes a function in which you can customize the underlying <code>DDTracerBuilder</code> instance to specify the service name, sampling rules, etc.</p>
+<p>At the end, the function should return a <code>datadog.opentracing.DDTracer</code>, for example by calling <code>build()</code>.</p>
+<p>The builder is mutable, so customizing it is considered an effect - hence the wrapping in <code>Sync[F].delay</code>:</p>
+<pre class="prettyprint"><code class="language-scala">import cats.effect.{Sync, Resource}
+import natchez.datadog.DDTracer
+import natchez.EntryPoint
+
+def entryPoint[F[_]: Sync]: Resource[F, EntryPoint[F]] =
+  DDTracer.entryPoint[F] {
+    builder =&gt; Sync[F].delay {
+      builder
+        .serviceName(&quot;my-app&quot;)
+        .build()
+    }
+  }
+</code></pre>
+<p>An alternative approach is to use the already registered global tracer (for example, if you&rsquo;ve already set it up and registered through some other means, like adding the Java Agent):</p>
+<pre class="prettyprint"><code class="language-scala">import java.net.URI
+
+// Will return `None` if there&#39;s no tracer registered already
+def entryPointUseGlobal[F[_]: Sync]: F[Option[EntryPoint[F]]] =
+  DDTracer.globalTracerEntryPoint[F](Some(new URI(s&quot;https://app.datadoghq.com&quot;)))
+</code></pre>
 <script type="text/javascript" src="../js/link_fix.js"></script>
 
 <div class="source-github">
-The source code for this page can be found <a id="source-link" href="https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/backends/datadog.md">here</a>.
+The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/datadog.md">here</a>.
 </div>
 
-<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/backends/datadog.md')});</script>
+<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/datadog.md')});</script>
 
 <div class="nav-next">
 <p><strong>Next:</strong> <a href="../backends/honeycomb.html">Honeycomb</a></p>
 </div>
 </div>
 <div class="large-3 show-for-large column" data-sticky-container>
+<nav class="sidebar sticky" data-sticky data-anchor="docs" data-sticky-on="large">
+<div class="page-nav">
+<div class="nav-title">On this page:</div>
+<div class="nav-toc">
+<ul>
+  <li><a href="../backends/datadog.html#datadog" class="header">Datadog</a>
+  <ul>
+    <li><a href="../backends/datadog.html#constructing-an-entrypoint" class="header">Constructing an EntryPoint</a></li>
+  </ul></li>
+</ul>
+</div>
+</div>
+</nav>
 </div>
 </div>
 
@@ -203,7 +252,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2021</span>
+<span class="text">&copy; 2025</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->
@@ -228,7 +277,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 <script type="text/javascript" src="../lib/prettify/prettify.js"></script>
 <script type="text/javascript" src="../lib/prettify/lang-scala.js"></script>
 <script type="text/javascript">jQuery(function(){window.prettyPrint && prettyPrint()});</script>
-<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.1.5', 'https://github.com/tpolecat/natchez')});</script>
+<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.3.7', 'https://github.com/typelevel/natchez')});</script>
 
 
 </html>

--- a/backends/honeycomb.html
+++ b/backends/honeycomb.html
@@ -6,7 +6,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content='docs'/>
-<link rel="canonical" href="https://github.com/tpolecat/natchezbackends/honeycomb.html"/>
+<link rel="canonical" href="https://github.com/typelevel/natchezbackends/honeycomb.html"/>
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="../lib/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="../js/page.js"></script>
@@ -32,7 +32,7 @@
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -58,6 +58,7 @@
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -95,7 +96,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -121,6 +122,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -153,14 +155,14 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <div class="page-content row">
 <div class="small-12 large-9 column" id="docs">
 <h1><a href="#honeycomb" name="honeycomb" class="anchor"><span class="anchor-link"></span></a>Honeycomb</h1>
-<p>To use the <a href="https://honeycomb.io">Honeycomb</a> back end, add the following dependency:</p><dl class="dependency"><dt>sbt</dt><dd><pre class="prettyprint"><code class="language-scala">libraryDependencies += "org.tpolecat" %% "natchez-honeycomb" % "0.1.5"</code></pre></dd><dt>Maven</dt><dd><pre class="prettyprint"><code class="language-xml">&lt;dependencies&gt
+<p>To use the <a href="https://honeycomb.io">Honeycomb</a> back end, add the following dependency:</p><dl class="dependency"><dt>sbt</dt><dd><pre class="prettyprint"><code class="language-scala">libraryDependencies += "org.tpolecat" %% "natchez-honeycomb" % "0.3.7"</code></pre></dd><dt>Maven</dt><dd><pre class="prettyprint"><code class="language-xml">&lt;dependencies&gt
   &lt;dependency&gt;
     &lt;groupId&gt;org.tpolecat&lt;/groupId&gt;
     &lt;artifactId&gt;natchez-honeycomb_2.13&lt;/artifactId&gt;
-    &lt;version&gt;0.1.5&lt;/version&gt;
+    &lt;version&gt;0.3.7&lt;/version&gt;
   &lt;/dependency&gt
 &lt;/dependencies&gt;</code></pre></dd><dt>Gradle</dt><dd><pre class="prettyprint"><code class="language-gradle">dependencies {
-  implementation "org.tpolecat:natchez-honeycomb_2.13:0.1.5"
+  implementation "org.tpolecat:natchez-honeycomb_2.13:0.3.7"
 }</code></pre></dd></dl>
 <h2><a href="#example-trace" name="example-trace" class="anchor"><span class="anchor-link"></span></a>Example Trace</h2>
 <p><img src="honeycomb.png" /></p>
@@ -192,7 +194,7 @@ def entryPoint[F[_]: Sync]: Resource[F, EntryPoint[F]] =
   </thead>
   <tbody>
     <tr>
-      <td><code>service_name</code> </td>
+      <td><code>service.name</code> </td>
       <td>String </td>
       <td>User-supplied service name. </td>
     </tr>
@@ -241,10 +243,10 @@ def entryPoint[F[_]: Sync]: Resource[F, EntryPoint[F]] =
 <script type="text/javascript" src="../js/link_fix.js"></script>
 
 <div class="source-github">
-The source code for this page can be found <a id="source-link" href="https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/backends/honeycomb.md">here</a>.
+The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/honeycomb.md">here</a>.
 </div>
 
-<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/backends/honeycomb.md')});</script>
+<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/honeycomb.md')});</script>
 
 <div class="nav-next">
 <p><strong>Next:</strong> <a href="../backends/jaeger.html">Jaeger</a></p>
@@ -303,7 +305,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2021</span>
+<span class="text">&copy; 2025</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->
@@ -328,7 +330,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 <script type="text/javascript" src="../lib/prettify/prettify.js"></script>
 <script type="text/javascript" src="../lib/prettify/lang-scala.js"></script>
 <script type="text/javascript">jQuery(function(){window.prettyPrint && prettyPrint()});</script>
-<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.1.5', 'https://github.com/tpolecat/natchez')});</script>
+<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.3.7', 'https://github.com/typelevel/natchez')});</script>
 
 
 </html>

--- a/backends/index.html
+++ b/backends/index.html
@@ -6,7 +6,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content='docs'/>
-<link rel="canonical" href="https://github.com/tpolecat/natchezbackends/index.html"/>
+<link rel="canonical" href="https://github.com/typelevel/natchezbackends/index.html"/>
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="../lib/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="../js/page.js"></script>
@@ -32,7 +32,7 @@
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -58,6 +58,7 @@
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -95,7 +96,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -121,6 +122,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -155,7 +157,10 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <p>Natchez supports the following tracing back ends. If you&rsquo;re not sure which one you&rsquo;d like to use, you might start with <a href="jaeger.html">Jaeger</a>, which is easy to set up with Docker.</p>
 <div class="toc ">
 <ul>
-  <li><a href="../backends/datadog.html" class="page">Datadog</a></li>
+  <li><a href="../backends/datadog.html" class="page">Datadog</a>
+  <ul>
+    <li><a href="../backends/datadog.html#constructing-an-entrypoint" class="header">Constructing an EntryPoint</a></li>
+  </ul></li>
   <li><a href="../backends/honeycomb.html" class="page">Honeycomb</a>
   <ul>
     <li><a href="../backends/honeycomb.html#example-trace" class="header">Example Trace</a></li>
@@ -175,15 +180,19 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
   <li><a href="../backends/noop.html" class="page">No-Op</a></li>
   <li><a href="../backends/odin.html" class="page">Odin</a></li>
   <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+  <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a>
+  <ul>
+    <li><a href="../backends/opentelemetry.html#configuring-an-opentelemetry-entrypoint" class="header">Configuring an OpenTelemetry entrypoint</a></li>
+  </ul></li>
 </ul>
 </div>
 <script type="text/javascript" src="../js/link_fix.js"></script>
 
 <div class="source-github">
-The source code for this page can be found <a id="source-link" href="https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/backends/index.md">here</a>.
+The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/index.md">here</a>.
 </div>
 
-<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/backends/index.md')});</script>
+<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/index.md')});</script>
 
 <div class="nav-next">
 <p><strong>Next:</strong> <a href="../backends/datadog.html">Datadog</a></p>
@@ -227,7 +236,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2021</span>
+<span class="text">&copy; 2025</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->
@@ -252,7 +261,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 <script type="text/javascript" src="../lib/prettify/prettify.js"></script>
 <script type="text/javascript" src="../lib/prettify/lang-scala.js"></script>
 <script type="text/javascript">jQuery(function(){window.prettyPrint && prettyPrint()});</script>
-<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.1.5', 'https://github.com/tpolecat/natchez')});</script>
+<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.3.7', 'https://github.com/typelevel/natchez')});</script>
 
 
 </html>

--- a/backends/jaeger.html
+++ b/backends/jaeger.html
@@ -6,7 +6,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content='docs'/>
-<link rel="canonical" href="https://github.com/tpolecat/natchezbackends/jaeger.html"/>
+<link rel="canonical" href="https://github.com/typelevel/natchezbackends/jaeger.html"/>
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="../lib/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="../js/page.js"></script>
@@ -32,7 +32,7 @@
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -58,6 +58,7 @@
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -95,7 +96,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -121,6 +122,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -156,10 +158,10 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <script type="text/javascript" src="../js/link_fix.js"></script>
 
 <div class="source-github">
-The source code for this page can be found <a id="source-link" href="https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/backends/jaeger.md">here</a>.
+The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/jaeger.md">here</a>.
 </div>
 
-<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/backends/jaeger.md')});</script>
+<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/jaeger.md')});</script>
 
 <div class="nav-next">
 <p><strong>Next:</strong> <a href="../backends/lightstep.html">Lightstep</a></p>
@@ -203,7 +205,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2021</span>
+<span class="text">&copy; 2025</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->
@@ -228,7 +230,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 <script type="text/javascript" src="../lib/prettify/prettify.js"></script>
 <script type="text/javascript" src="../lib/prettify/lang-scala.js"></script>
 <script type="text/javascript">jQuery(function(){window.prettyPrint && prettyPrint()});</script>
-<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.1.5', 'https://github.com/tpolecat/natchez')});</script>
+<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.3.7', 'https://github.com/typelevel/natchez')});</script>
 
 
 </html>

--- a/backends/lightstep.html
+++ b/backends/lightstep.html
@@ -6,7 +6,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content='docs'/>
-<link rel="canonical" href="https://github.com/tpolecat/natchezbackends/lightstep.html"/>
+<link rel="canonical" href="https://github.com/typelevel/natchezbackends/lightstep.html"/>
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="../lib/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="../js/page.js"></script>
@@ -32,7 +32,7 @@
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -58,6 +58,7 @@
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -95,7 +96,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -121,6 +122,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -156,10 +158,10 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <script type="text/javascript" src="../js/link_fix.js"></script>
 
 <div class="source-github">
-The source code for this page can be found <a id="source-link" href="https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/backends/lightstep.md">here</a>.
+The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/lightstep.md">here</a>.
 </div>
 
-<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/backends/lightstep.md')});</script>
+<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/lightstep.md')});</script>
 
 <div class="nav-next">
 <p><strong>Next:</strong> <a href="../backends/log.html">Log</a></p>
@@ -203,7 +205,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2021</span>
+<span class="text">&copy; 2025</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->
@@ -228,7 +230,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 <script type="text/javascript" src="../lib/prettify/prettify.js"></script>
 <script type="text/javascript" src="../lib/prettify/lang-scala.js"></script>
 <script type="text/javascript">jQuery(function(){window.prettyPrint && prettyPrint()});</script>
-<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.1.5', 'https://github.com/tpolecat/natchez')});</script>
+<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.3.7', 'https://github.com/typelevel/natchez')});</script>
 
 
 </html>

--- a/backends/log.html
+++ b/backends/log.html
@@ -6,7 +6,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content='docs'/>
-<link rel="canonical" href="https://github.com/tpolecat/natchezbackends/log.html"/>
+<link rel="canonical" href="https://github.com/typelevel/natchezbackends/log.html"/>
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="../lib/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="../js/page.js"></script>
@@ -32,7 +32,7 @@
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -58,6 +58,7 @@
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -95,7 +96,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -121,6 +122,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -153,37 +155,43 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <div class="page-content row">
 <div class="small-12 large-9 column" id="docs">
 <h1><a href="#log" name="log" class="anchor"><span class="anchor-link"></span></a>Log</h1>
-<p>The <code>natchez-log</code> module provides a back end that logs traces locally (as JSON) to a <a href="https://github.com/typelevel/log4cats">log4cats</a> <code>Logger</code>, with no distributed functionality. To use it, add the following dependency.</p><dl class="dependency"><dt>sbt</dt><dd><pre class="prettyprint"><code class="language-scala">libraryDependencies += "org.tpolecat" %% "natchez-log" % "0.1.5"</code></pre></dd><dt>Maven</dt><dd><pre class="prettyprint"><code class="language-xml">&lt;dependencies&gt
+<p>The <code>natchez-log</code> module provides a back end that logs traces locally (as JSON) to a <a href="https://github.com/typelevel/log4cats">log4cats</a> <code>Logger</code>, with no distributed functionality. To use it, add the following dependency.</p><dl class="dependency"><dt>sbt</dt><dd><pre class="prettyprint"><code class="language-scala">libraryDependencies += "org.tpolecat" %% "natchez-log" % "0.3.7"</code></pre></dd><dt>Maven</dt><dd><pre class="prettyprint"><code class="language-xml">&lt;dependencies&gt
   &lt;dependency&gt;
     &lt;groupId&gt;org.tpolecat&lt;/groupId&gt;
     &lt;artifactId&gt;natchez-log_2.13&lt;/artifactId&gt;
-    &lt;version&gt;0.1.5&lt;/version&gt;
+    &lt;version&gt;0.3.7&lt;/version&gt;
   &lt;/dependency&gt
 &lt;/dependencies&gt;</code></pre></dd><dt>Gradle</dt><dd><pre class="prettyprint"><code class="language-gradle">dependencies {
-  implementation "org.tpolecat:natchez-log_2.13:0.1.5"
+  implementation "org.tpolecat:natchez-log_2.13:0.3.7"
 }</code></pre></dd></dl>
 <h2><a href="#example-trace" name="example-trace" class="anchor"><span class="anchor-link"></span></a>Example Trace</h2>
 <p>The log handler constructs a JSON object for each root span, with a <code>children</code> collection of child spans. On completion of the root span the entire JSON blob is logged as a single message. Here is an example with a root span containing two custom fields and two child spans.</p>
 <pre class="prettyprint"><code class="language-json">{
   &quot;name&quot; : &quot;root span&quot;,
   &quot;service&quot; : &quot;example-service&quot;,
-  &quot;timestamp&quot; : &quot;2021-05-26T16:41:09.221325Z&quot;,
-  &quot;duration_ms&quot; : 108,
-  &quot;trace.span_id&quot; : &quot;dd817430-c00a-423e-9db4-0a24897b9cb9&quot;,
+  &quot;timestamp&quot; : &quot;2025-01-17T16:01:57.522113Z&quot;,
+  &quot;duration_ms&quot; : 72,
+  &quot;trace.span_id&quot; : &quot;7f8de43a-5aa3-49e5-8dda-158b6a74bab0&quot;,
   &quot;trace.parent_id&quot; : null,
-  &quot;trace.trace_id&quot; : &quot;ef7758f0-7b33-4358-81f5-4f2070f7196d&quot;,
-  &quot;exit.case&quot; : &quot;succeeded&quot;,
+  &quot;trace.trace_id&quot; : &quot;1f6721c6-d67d-41ed-9d26-20e65ec7b79f&quot;,
+  &quot;span.kind&quot; : &quot;Internal&quot;,
+  &quot;span.links&quot; : [
+  ],
   &quot;person.name&quot; : &quot;bob&quot;,
   &quot;person.age&quot; : 42,
+  &quot;exit.case&quot; : &quot;succeeded&quot;,
   &quot;children&quot; : [
     {
       &quot;name&quot; : &quot;thing one&quot;,
       &quot;service&quot; : &quot;example-service&quot;,
-      &quot;timestamp&quot; : &quot;2021-05-26T16:41:09.301796Z&quot;,
-      &quot;duration_ms&quot; : 3,
-      &quot;trace.span_id&quot; : &quot;93f6aab7-b89d-4c11-b21a-2272ae6f5697&quot;,
-      &quot;trace.parent_id&quot; : &quot;ef7758f0-7b33-4358-81f5-4f2070f7196d&quot;,
-      &quot;trace.trace_id&quot; : &quot;ef7758f0-7b33-4358-81f5-4f2070f7196d&quot;,
+      &quot;timestamp&quot; : &quot;2025-01-17T16:01:57.578712Z&quot;,
+      &quot;duration_ms&quot; : 1,
+      &quot;trace.span_id&quot; : &quot;29c8cd00-f971-49aa-bed3-677574740612&quot;,
+      &quot;trace.parent_id&quot; : &quot;7f8de43a-5aa3-49e5-8dda-158b6a74bab0&quot;,
+      &quot;trace.trace_id&quot; : &quot;1f6721c6-d67d-41ed-9d26-20e65ec7b79f&quot;,
+      &quot;span.kind&quot; : &quot;Internal&quot;,
+      &quot;span.links&quot; : [
+      ],
       &quot;exit.case&quot; : &quot;succeeded&quot;,
       &quot;children&quot; : [
       ]
@@ -191,11 +199,14 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     {
       &quot;name&quot; : &quot;thing two&quot;,
       &quot;service&quot; : &quot;example-service&quot;,
-      &quot;timestamp&quot; : &quot;2021-05-26T16:41:09.328357Z&quot;,
+      &quot;timestamp&quot; : &quot;2025-01-17T16:01:57.593398Z&quot;,
       &quot;duration_ms&quot; : 1,
-      &quot;trace.span_id&quot; : &quot;f94c8eed-8c1a-4c02-b40e-36266e40b4d5&quot;,
-      &quot;trace.parent_id&quot; : &quot;ef7758f0-7b33-4358-81f5-4f2070f7196d&quot;,
-      &quot;trace.trace_id&quot; : &quot;ef7758f0-7b33-4358-81f5-4f2070f7196d&quot;,
+      &quot;trace.span_id&quot; : &quot;b33af3ef-7f04-4526-8579-4e6ef2c2d521&quot;,
+      &quot;trace.parent_id&quot; : &quot;7f8de43a-5aa3-49e5-8dda-158b6a74bab0&quot;,
+      &quot;trace.trace_id&quot; : &quot;1f6721c6-d67d-41ed-9d26-20e65ec7b79f&quot;,
+      &quot;span.kind&quot; : &quot;Internal&quot;,
+      &quot;span.links&quot; : [
+      ],
       &quot;exit.case&quot; : &quot;succeeded&quot;,
       &quot;children&quot; : [
       ]
@@ -290,10 +301,10 @@ val ep: EntryPoint[IO] =
 <script type="text/javascript" src="../js/link_fix.js"></script>
 
 <div class="source-github">
-The source code for this page can be found <a id="source-link" href="https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/backends/log.md">here</a>.
+The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/log.md">here</a>.
 </div>
 
-<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/backends/log.md')});</script>
+<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/log.md')});</script>
 
 <div class="nav-next">
 <p><strong>Next:</strong> <a href="../backends/mock.html">Mock</a></p>
@@ -352,7 +363,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2021</span>
+<span class="text">&copy; 2025</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->
@@ -377,7 +388,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 <script type="text/javascript" src="../lib/prettify/prettify.js"></script>
 <script type="text/javascript" src="../lib/prettify/lang-scala.js"></script>
 <script type="text/javascript">jQuery(function(){window.prettyPrint && prettyPrint()});</script>
-<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.1.5', 'https://github.com/tpolecat/natchez')});</script>
+<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.3.7', 'https://github.com/typelevel/natchez')});</script>
 
 
 </html>

--- a/backends/mock.html
+++ b/backends/mock.html
@@ -6,7 +6,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content='docs'/>
-<link rel="canonical" href="https://github.com/tpolecat/natchezbackends/mock.html"/>
+<link rel="canonical" href="https://github.com/typelevel/natchezbackends/mock.html"/>
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="../lib/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="../js/page.js"></script>
@@ -32,7 +32,7 @@
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -58,6 +58,7 @@
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -95,7 +96,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -121,6 +122,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -156,10 +158,10 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <script type="text/javascript" src="../js/link_fix.js"></script>
 
 <div class="source-github">
-The source code for this page can be found <a id="source-link" href="https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/backends/mock.md">here</a>.
+The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/mock.md">here</a>.
 </div>
 
-<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/backends/mock.md')});</script>
+<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/mock.md')});</script>
 
 <div class="nav-next">
 <p><strong>Next:</strong> <a href="../backends/newrelic.html">New Relic</a></p>
@@ -203,7 +205,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2021</span>
+<span class="text">&copy; 2025</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->
@@ -228,7 +230,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 <script type="text/javascript" src="../lib/prettify/prettify.js"></script>
 <script type="text/javascript" src="../lib/prettify/lang-scala.js"></script>
 <script type="text/javascript">jQuery(function(){window.prettyPrint && prettyPrint()});</script>
-<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.1.5', 'https://github.com/tpolecat/natchez')});</script>
+<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.3.7', 'https://github.com/typelevel/natchez')});</script>
 
 
 </html>

--- a/backends/newrelic.html
+++ b/backends/newrelic.html
@@ -6,7 +6,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content='docs'/>
-<link rel="canonical" href="https://github.com/tpolecat/natchezbackends/newrelic.html"/>
+<link rel="canonical" href="https://github.com/typelevel/natchezbackends/newrelic.html"/>
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="../lib/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="../js/page.js"></script>
@@ -32,7 +32,7 @@
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -58,6 +58,7 @@
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -95,7 +96,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -121,6 +122,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -156,10 +158,10 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <script type="text/javascript" src="../js/link_fix.js"></script>
 
 <div class="source-github">
-The source code for this page can be found <a id="source-link" href="https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/backends/newrelic.md">here</a>.
+The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/newrelic.md">here</a>.
 </div>
 
-<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/backends/newrelic.md')});</script>
+<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/newrelic.md')});</script>
 
 <div class="nav-next">
 <p><strong>Next:</strong> <a href="../backends/noop.html">No-Op</a></p>
@@ -203,7 +205,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2021</span>
+<span class="text">&copy; 2025</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->
@@ -228,7 +230,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 <script type="text/javascript" src="../lib/prettify/prettify.js"></script>
 <script type="text/javascript" src="../lib/prettify/lang-scala.js"></script>
 <script type="text/javascript">jQuery(function(){window.prettyPrint && prettyPrint()});</script>
-<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.1.5', 'https://github.com/tpolecat/natchez')});</script>
+<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.3.7', 'https://github.com/typelevel/natchez')});</script>
 
 
 </html>

--- a/backends/noop.html
+++ b/backends/noop.html
@@ -6,7 +6,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content='docs'/>
-<link rel="canonical" href="https://github.com/tpolecat/natchezbackends/noop.html"/>
+<link rel="canonical" href="https://github.com/typelevel/natchezbackends/noop.html"/>
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="../lib/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="../js/page.js"></script>
@@ -32,7 +32,7 @@
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -58,6 +58,7 @@
     <li><a href="../backends/noop.html" class="active page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -95,7 +96,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -121,6 +122,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <li><a href="../backends/noop.html" class="active page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -168,10 +170,10 @@ def go = foo[Option]
 <script type="text/javascript" src="../js/link_fix.js"></script>
 
 <div class="source-github">
-The source code for this page can be found <a id="source-link" href="https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/backends/noop.md">here</a>.
+The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/noop.md">here</a>.
 </div>
 
-<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/backends/noop.md')});</script>
+<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/noop.md')});</script>
 
 <div class="nav-next">
 <p><strong>Next:</strong> <a href="../backends/odin.html">Odin</a></p>
@@ -215,7 +217,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2021</span>
+<span class="text">&copy; 2025</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->
@@ -240,7 +242,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 <script type="text/javascript" src="../lib/prettify/prettify.js"></script>
 <script type="text/javascript" src="../lib/prettify/lang-scala.js"></script>
 <script type="text/javascript">jQuery(function(){window.prettyPrint && prettyPrint()});</script>
-<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.1.5', 'https://github.com/tpolecat/natchez')});</script>
+<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.3.7', 'https://github.com/typelevel/natchez')});</script>
 
 
 </html>

--- a/backends/odin.html
+++ b/backends/odin.html
@@ -6,7 +6,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content='docs'/>
-<link rel="canonical" href="https://github.com/tpolecat/natchezbackends/odin.html"/>
+<link rel="canonical" href="https://github.com/typelevel/natchezbackends/odin.html"/>
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="../lib/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="../js/page.js"></script>
@@ -32,7 +32,7 @@
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -58,6 +58,7 @@
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="active page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -95,7 +96,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -121,6 +122,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="active page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -156,10 +158,10 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <script type="text/javascript" src="../js/link_fix.js"></script>
 
 <div class="source-github">
-The source code for this page can be found <a id="source-link" href="https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/backends/odin.md">here</a>.
+The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/odin.md">here</a>.
 </div>
 
-<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/backends/odin.md')});</script>
+<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/odin.md')});</script>
 
 <div class="nav-next">
 <p><strong>Next:</strong> <a href="../backends/opencensus.html">OpenCensus</a></p>
@@ -203,7 +205,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2021</span>
+<span class="text">&copy; 2025</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->
@@ -228,7 +230,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 <script type="text/javascript" src="../lib/prettify/prettify.js"></script>
 <script type="text/javascript" src="../lib/prettify/lang-scala.js"></script>
 <script type="text/javascript">jQuery(function(){window.prettyPrint && prettyPrint()});</script>
-<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.1.5', 'https://github.com/tpolecat/natchez')});</script>
+<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.3.7', 'https://github.com/typelevel/natchez')});</script>
 
 
 </html>

--- a/backends/opencensus.html
+++ b/backends/opencensus.html
@@ -6,7 +6,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content='docs'/>
-<link rel="canonical" href="https://github.com/tpolecat/natchezbackends/opencensus.html"/>
+<link rel="canonical" href="https://github.com/typelevel/natchezbackends/opencensus.html"/>
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="../lib/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="../js/page.js"></script>
@@ -32,7 +32,7 @@
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -58,6 +58,7 @@
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="active page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -95,7 +96,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -121,6 +122,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="active page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -156,13 +158,13 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <script type="text/javascript" src="../js/link_fix.js"></script>
 
 <div class="source-github">
-The source code for this page can be found <a id="source-link" href="https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/backends/opencensus.md">here</a>.
+The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/opencensus.md">here</a>.
 </div>
 
-<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/backends/opencensus.md')});</script>
+<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/opencensus.md')});</script>
 
 <div class="nav-next">
-<p><strong>Next:</strong> <a href="../examples/index.html">Examples</a></p>
+<p><strong>Next:</strong> <a href="../backends/opentelemetry.html">OpenTelemetry</a></p>
 </div>
 </div>
 <div class="large-3 show-for-large column" data-sticky-container>
@@ -203,7 +205,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2021</span>
+<span class="text">&copy; 2025</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->
@@ -228,7 +230,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 <script type="text/javascript" src="../lib/prettify/prettify.js"></script>
 <script type="text/javascript" src="../lib/prettify/lang-scala.js"></script>
 <script type="text/javascript">jQuery(function(){window.prettyPrint && prettyPrint()});</script>
-<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.1.5', 'https://github.com/tpolecat/natchez')});</script>
+<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.3.7', 'https://github.com/typelevel/natchez')});</script>
 
 
 </html>

--- a/backends/opentelemetry.html
+++ b/backends/opentelemetry.html
@@ -2,11 +2,11 @@
 <html class="no-js" lang="en">
 
 <head>
-<title>Skunk · Natchez</title>
+<title>OpenTelemetry · Natchez</title>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content='docs'/>
-<link rel="canonical" href="https://github.com/typelevel/natchezexamples/skunk.html"/>
+<link rel="canonical" href="https://github.com/typelevel/natchezbackends/opentelemetry.html"/>
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="../lib/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="../js/page.js"></script>
@@ -58,12 +58,12 @@
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
-    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
+    <li><a href="../backends/opentelemetry.html" class="active page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
     <li><a href="../examples/http4s.html" class="page">Http4s</a></li>
-    <li><a href="../examples/skunk.html" class="active page">Skunk</a></li>
+    <li><a href="../examples/skunk.html" class="page">Skunk</a></li>
   </ul></li>
 </ul>
 </div>
@@ -122,12 +122,12 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
-    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
+    <li><a href="../backends/opentelemetry.html" class="active page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
     <li><a href="../examples/http4s.html" class="page">Http4s</a></li>
-    <li><a href="../examples/skunk.html" class="active page">Skunk</a></li>
+    <li><a href="../examples/skunk.html" class="page">Skunk</a></li>
   </ul></li>
 </ul>
 </div>
@@ -145,8 +145,8 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <div class="nav-breadcrumbs">
 <ul>
   <li><a href="../index.html">Natchez</a></li>
-  <li><a href="../examples/index.html">Examples</a></li>
-  <li>Skunk</li>
+  <li><a href="../backends/index.html">Back Ends</a></li>
+  <li>OpenTelemetry</li>
 </ul>
 </div>
 </div>
@@ -154,17 +154,58 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 
 <div class="page-content row">
 <div class="small-12 large-9 column" id="docs">
-<h1><a href="#skunk" name="skunk" class="anchor"><span class="anchor-link"></span></a>Skunk</h1>
+<h1><a href="#opentelemetry" name="opentelemetry" class="anchor"><span class="anchor-link"></span></a>OpenTelemetry</h1>
+<p>The <code>natchez-opentelemetry</code> module provides a backend that uses <a href="https://opentelemetry.io">OpenTelemetry</a> to report spans.</p>
+<p>To use it, add the following dependency.</p><dl class="dependency"><dt>sbt</dt><dd><pre class="prettyprint"><code class="language-scala">libraryDependencies += "org.tpolecat" % "natchez-opentelemetry-2.13" % "0.3.7"</code></pre></dd><dt>Maven</dt><dd><pre class="prettyprint"><code class="language-xml">&lt;dependencies&gt
+  &lt;dependency&gt;
+    &lt;groupId&gt;org.tpolecat&lt;/groupId&gt;
+    &lt;artifactId&gt;natchez-opentelemetry-2.13&lt;/artifactId&gt;
+    &lt;version&gt;0.3.7&lt;/version&gt;
+  &lt;/dependency&gt
+&lt;/dependencies&gt;</code></pre></dd><dt>Gradle</dt><dd><pre class="prettyprint"><code class="language-gradle">dependencies {
+  implementation "org.tpolecat:natchez-opentelemetry-2.13:0.3.7"
+}</code></pre></dd></dl>
+<p>Then add any exporter, for example:</p><dl class="dependency"><dt>sbt</dt><dd><pre class="prettyprint"><code class="language-scala">libraryDependencies += "io.opentelemetry" % "opentelemetry-exporter-otlp" % "1.12.0"</code></pre></dd><dt>Maven</dt><dd><pre class="prettyprint"><code class="language-xml">&lt;dependencies&gt
+  &lt;dependency&gt;
+    &lt;groupId&gt;io.opentelemetry&lt;/groupId&gt;
+    &lt;artifactId&gt;opentelemetry-exporter-otlp&lt;/artifactId&gt;
+    &lt;version&gt;1.12.0&lt;/version&gt;
+  &lt;/dependency&gt
+&lt;/dependencies&gt;</code></pre></dd><dt>Gradle</dt><dd><pre class="prettyprint"><code class="language-gradle">dependencies {
+  implementation "io.opentelemetry:opentelemetry-exporter-otlp:1.12.0"
+}</code></pre></dd></dl>
+<h2><a href="#configuring-an-opentelemetry-entrypoint" name="configuring-an-opentelemetry-entrypoint" class="anchor"><span class="anchor-link"></span></a>Configuring an OpenTelemetry entrypoint</h2>
+<p>There are two methods you&rsquo;ll need to construct an <code>OpenTelemetry</code> <code>EndPoint</code>.</p>
+<p><code>OpenTelemetry.lift</code> is used to turn an <code>F[_]</code> that constructs a <code>SpanExporter</code>, <code>SpanProcessor</code> or <code>SdkTraceProvider</code> into a <code>Resource</code> that will shut it down cleanly. This takes a <code>String</code> of what you&rsquo;ve constructed, so we can give a nice error if it fails to shut down cleanly.</p>
+<p>The <code>OpenTelemetry.entryPoint</code> method takes a boolean called <code>globallyRegister</code> which tells it whether to register this <code>OpenTelemetry</code> globally. This may be helpful if you have other Java dependencies that use the global tracer. It defaults to false.</p>
+<p>It also takes an <code>OpenTelemetrySdkBuilder =&gt; Resource[F, OpenTelemetrySdkBuilder]</code> so that you can configure the Sdk.</p>
+<p>Here&rsquo;s an example of configuring one with the <code>otlp</code> exporter with batch span processing:</p>
 <script type="text/javascript" src="../js/link_fix.js"></script>
 
 <div class="source-github">
-The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/examples/skunk.md">here</a>.
+The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/opentelemetry.md">here</a>.
 </div>
 
-<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/examples/skunk.md')});</script>
+<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/backends/opentelemetry.md')});</script>
 
+<div class="nav-next">
+<p><strong>Next:</strong> <a href="../examples/index.html">Examples</a></p>
+</div>
 </div>
 <div class="large-3 show-for-large column" data-sticky-container>
+<nav class="sidebar sticky" data-sticky data-anchor="docs" data-sticky-on="large">
+<div class="page-nav">
+<div class="nav-title">On this page:</div>
+<div class="nav-toc">
+<ul>
+  <li><a href="../backends/opentelemetry.html#opentelemetry" class="header">OpenTelemetry</a>
+  <ul>
+    <li><a href="../backends/opentelemetry.html#configuring-an-opentelemetry-entrypoint" class="header">Configuring an OpenTelemetry entrypoint</a></li>
+  </ul></li>
+</ul>
+</div>
+</div>
+</nav>
 </div>
 </div>
 

--- a/examples/http4s.html
+++ b/examples/http4s.html
@@ -6,7 +6,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content='docs'/>
-<link rel="canonical" href="https://github.com/tpolecat/natchezexamples/http4s.html"/>
+<link rel="canonical" href="https://github.com/typelevel/natchezexamples/http4s.html"/>
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="../lib/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="../js/page.js"></script>
@@ -32,7 +32,7 @@
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -58,6 +58,7 @@
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -95,7 +96,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -121,6 +122,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -156,10 +158,10 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <script type="text/javascript" src="../js/link_fix.js"></script>
 
 <div class="source-github">
-The source code for this page can be found <a id="source-link" href="https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/examples/http4s.md">here</a>.
+The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/examples/http4s.md">here</a>.
 </div>
 
-<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/examples/http4s.md')});</script>
+<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/examples/http4s.md')});</script>
 
 <div class="nav-next">
 <p><strong>Next:</strong> <a href="../examples/skunk.html">Skunk</a></p>
@@ -203,7 +205,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2021</span>
+<span class="text">&copy; 2025</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->
@@ -228,7 +230,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 <script type="text/javascript" src="../lib/prettify/prettify.js"></script>
 <script type="text/javascript" src="../lib/prettify/lang-scala.js"></script>
 <script type="text/javascript">jQuery(function(){window.prettyPrint && prettyPrint()});</script>
-<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.1.5', 'https://github.com/tpolecat/natchez')});</script>
+<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.3.7', 'https://github.com/typelevel/natchez')});</script>
 
 
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -6,7 +6,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content='docs'/>
-<link rel="canonical" href="https://github.com/tpolecat/natchezexamples/index.html"/>
+<link rel="canonical" href="https://github.com/typelevel/natchezexamples/index.html"/>
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="../lib/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="../js/page.js"></script>
@@ -32,7 +32,7 @@
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -58,6 +58,7 @@
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="active page">Examples</a>
   <ul>
@@ -95,7 +96,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -121,6 +122,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="active page">Examples</a>
   <ul>
@@ -155,10 +157,10 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <script type="text/javascript" src="../js/link_fix.js"></script>
 
 <div class="source-github">
-The source code for this page can be found <a id="source-link" href="https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/examples/index.md">here</a>.
+The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/examples/index.md">here</a>.
 </div>
 
-<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/examples/index.md')});</script>
+<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/examples/index.md')});</script>
 
 <div class="nav-next">
 <p><strong>Next:</strong> <a href="../examples/http4s.html">Http4s</a></p>
@@ -202,7 +204,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2021</span>
+<span class="text">&copy; 2025</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->
@@ -227,7 +229,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 <script type="text/javascript" src="../lib/prettify/prettify.js"></script>
 <script type="text/javascript" src="../lib/prettify/lang-scala.js"></script>
 <script type="text/javascript">jQuery(function(){window.prettyPrint && prettyPrint()});</script>
-<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.1.5', 'https://github.com/tpolecat/natchez')});</script>
+<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.3.7', 'https://github.com/typelevel/natchez')});</script>
 
 
 </html>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content='docs'/>
-<link rel="canonical" href="https://github.com/tpolecat/natchezindex.html"/>
+<link rel="canonical" href="https://github.com/typelevel/natchezindex.html"/>
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="lib/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="js/page.js"></script>
@@ -32,7 +32,7 @@
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -58,6 +58,7 @@
     <li><a href="backends/noop.html" class="page">No-Op</a></li>
     <li><a href="backends/odin.html" class="page">Odin</a></li>
     <li><a href="backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="examples/index.html" class="page">Examples</a>
   <ul>
@@ -95,7 +96,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -121,6 +122,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <li><a href="backends/noop.html" class="page">No-Op</a></li>
     <li><a href="backends/odin.html" class="page">Odin</a></li>
     <li><a href="backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="examples/index.html" class="page">Examples</a>
   <ul>
@@ -151,7 +153,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <p><em>The Natchez Trace, also known as the &ldquo;Old Natchez Trace&rdquo;, is a historic forest trail within the United States which extends roughly 440 miles (710 km) from Nashville, Tennessee, to Natchez, Mississippi, linking the Cumberland, Tennessee, and Mississippi rivers.</em></p>
 <p><em>Credits: <a href="https://en.wikipedia.org/wiki/Natchez_Trace">Wikipedia</a> and the <a href="https://www.nps.gov/natr/index.htm">National Park Service</a>.</em></p>
 <h2><a href="#welcome-" name="welcome-" class="anchor"><span class="anchor-link"></span></a>Welcome!</h2>
-<p><strong>Natchez</strong> is a minimal distributed tracing library for Cats, inspired by earlier work done on <a href="https://github.com/tabdulradi/puretracing">puretracing</a>. Natchez is published for <strong>Scala 2.12/2.13/3.0</strong>, with limited support for Scala-JS.</p>
+<p><strong>Natchez</strong> is a minimal distributed tracing library for Cats, inspired by earlier work done on <a href="https://github.com/tabdulradi/puretracing">puretracing</a>. Natchez is published for <strong>Scala 2.12/2.13/3.3</strong>, with limited support for Scala-JS.</p>
 <p>Below are the available version series (see <a href="https://github.com/tpolecat/natchez/releases">releases</a> for exact version numbers). You are strongly encouraged to use the <strong>Active</strong> series. Older series will receive bug fixes when necessary but are not actively maintained.</p>
 <table>
   <thead>
@@ -192,14 +194,14 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
       <p>If you wish to write <strong>application code</strong> then you should use the dependency specific to your tracing <a href="backends/index.html">back end</a>.</p></li>
       <li>
       <p>If you wish to write <strong>library code</strong> that supports any tracing back-end, then you should use the core dependency below (also available for Scala-JS).</p></li>
-    </ul><dl class="dependency"><dt>sbt</dt><dd><pre class="prettyprint"><code class="language-scala">libraryDependencies += "org.tpolecat" %% "natchez-core" % "0.1.5"</code></pre></dd><dt>Maven</dt><dd><pre class="prettyprint"><code class="language-xml">&lt;dependencies&gt
+    </ul><dl class="dependency"><dt>sbt</dt><dd><pre class="prettyprint"><code class="language-scala">libraryDependencies += "org.tpolecat" %% "natchez-core" % "0.3.7"</code></pre></dd><dt>Maven</dt><dd><pre class="prettyprint"><code class="language-xml">&lt;dependencies&gt
   &lt;dependency&gt;
     &lt;groupId&gt;org.tpolecat&lt;/groupId&gt;
     &lt;artifactId&gt;natchez-core_2.13&lt;/artifactId&gt;
-    &lt;version&gt;0.1.5&lt;/version&gt;
+    &lt;version&gt;0.3.7&lt;/version&gt;
   &lt;/dependency&gt
 &lt;/dependencies&gt;</code></pre></dd><dt>Gradle</dt><dd><pre class="prettyprint"><code class="language-gradle">dependencies {
-  implementation "org.tpolecat:natchez-core_2.13:0.1.5"
+  implementation "org.tpolecat:natchez-core_2.13:0.3.7"
 }</code></pre></dd></dl>
   </li>
   <li>
@@ -207,7 +209,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <p>Natchez is written for <a href="http://typelevel.org/cats/">cats</a> and <a href="https://typelevel.org/cats-effect/">cats-effect</a>. This documentation assumes you are familiar with pure-functional programming with effects, including use of <code>Resource</code> and tagless-final coding style. If you run into trouble be sure to check out:</p>
     <ul>
       <li>The Natchez channel on <a href="https://sca.la/typeleveldiscord">Typelevel Discord</a>.</li>
-      <li>The <a href="https://javadoc.io/doc/org.tpolecat/natchez-core_2.13/0.1.5/index.html">API Documentation</a>.</li>
+      <li>The <a href="https://javadoc.io/doc/org.tpolecat/natchez-core_2.13/0.3.7/index.html">API Documentation</a>.</li>
     </ul>
   </li>
   <li>
@@ -224,10 +226,10 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <script type="text/javascript" src="js/link_fix.js"></script>
 
 <div class="source-github">
-The source code for this page can be found <a id="source-link" href="https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/index.md">here</a>.
+The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/index.md">here</a>.
 </div>
 
-<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/index.md')});</script>
+<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/index.md')});</script>
 
 <div class="nav-next">
 <p><strong>Next:</strong> <a href="overview.html">Overview</a></p>
@@ -286,7 +288,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2021</span>
+<span class="text">&copy; 2025</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->
@@ -311,7 +313,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 <script type="text/javascript" src="lib/prettify/prettify.js"></script>
 <script type="text/javascript" src="lib/prettify/lang-scala.js"></script>
 <script type="text/javascript">jQuery(function(){window.prettyPrint && prettyPrint()});</script>
-<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.1.5', 'https://github.com/tpolecat/natchez')});</script>
+<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.3.7', 'https://github.com/typelevel/natchez')});</script>
 
 
 </html>

--- a/overview.html
+++ b/overview.html
@@ -6,7 +6,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content='docs'/>
-<link rel="canonical" href="https://github.com/tpolecat/natchezoverview.html"/>
+<link rel="canonical" href="https://github.com/typelevel/natchezoverview.html"/>
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="lib/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="js/page.js"></script>
@@ -32,7 +32,7 @@
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -58,6 +58,7 @@
     <li><a href="backends/noop.html" class="page">No-Op</a></li>
     <li><a href="backends/odin.html" class="page">Odin</a></li>
     <li><a href="backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="examples/index.html" class="page">Examples</a>
   <ul>
@@ -95,7 +96,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -121,6 +122,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <li><a href="backends/noop.html" class="page">No-Op</a></li>
     <li><a href="backends/odin.html" class="page">Odin</a></li>
     <li><a href="backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="examples/index.html" class="page">Examples</a>
   <ul>
@@ -174,10 +176,10 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <script type="text/javascript" src="js/link_fix.js"></script>
 
 <div class="source-github">
-The source code for this page can be found <a id="source-link" href="https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/overview.md">here</a>.
+The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/overview.md">here</a>.
 </div>
 
-<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/overview.md')});</script>
+<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/overview.md')});</script>
 
 <div class="nav-next">
 <p><strong>Next:</strong> <a href="reference/index.html">Reference</a></p>
@@ -236,7 +238,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2021</span>
+<span class="text">&copy; 2025</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->
@@ -261,7 +263,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 <script type="text/javascript" src="lib/prettify/prettify.js"></script>
 <script type="text/javascript" src="lib/prettify/lang-scala.js"></script>
 <script type="text/javascript">jQuery(function(){window.prettyPrint && prettyPrint()});</script>
-<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.1.5', 'https://github.com/tpolecat/natchez')});</script>
+<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.3.7', 'https://github.com/typelevel/natchez')});</script>
 
 
 </html>

--- a/paradox.json
+++ b/paradox.json
@@ -1,4 +1,4 @@
 {
   "name" : "docs",
-  "version" : "0.1.5"
+  "version" : "0.3.7"
 }

--- a/reference/entrypoints.html
+++ b/reference/entrypoints.html
@@ -6,7 +6,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content='docs'/>
-<link rel="canonical" href="https://github.com/tpolecat/natchezreference/entrypoints.html"/>
+<link rel="canonical" href="https://github.com/typelevel/natchezreference/entrypoints.html"/>
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="../lib/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="../js/page.js"></script>
@@ -32,7 +32,7 @@
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -58,6 +58,7 @@
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -95,7 +96,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -121,6 +122,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -185,7 +187,7 @@ import org.http4s.dsl.io._
     case req@(GET -&gt; Root / &quot;hello&quot; / name) =&gt;
 
       val k: Kernel =
-        Kernel(req.headers.headers.map { h =&gt; h.name.toString -&gt; h.value }.toMap)
+        Kernel(req.headers.headers.map { h =&gt; h.name -&gt; h.value }.toMap)
 
       ep.continueOrElseRoot(&quot;hello&quot;, k).use { span =&gt;
         span.put(&quot;the-name&quot; -&gt; name) *&gt;
@@ -198,10 +200,10 @@ import org.http4s.dsl.io._
 <script type="text/javascript" src="../js/link_fix.js"></script>
 
 <div class="source-github">
-The source code for this page can be found <a id="source-link" href="https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/reference/entrypoints.md">here</a>.
+The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/reference/entrypoints.md">here</a>.
 </div>
 
-<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/reference/entrypoints.md')});</script>
+<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/reference/entrypoints.md')});</script>
 
 <div class="nav-next">
 <p><strong>Next:</strong> <a href="../reference/kernels.html">Kernels</a></p>
@@ -259,7 +261,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2021</span>
+<span class="text">&copy; 2025</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->
@@ -284,7 +286,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 <script type="text/javascript" src="../lib/prettify/prettify.js"></script>
 <script type="text/javascript" src="../lib/prettify/lang-scala.js"></script>
 <script type="text/javascript">jQuery(function(){window.prettyPrint && prettyPrint()});</script>
-<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.1.5', 'https://github.com/tpolecat/natchez')});</script>
+<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.3.7', 'https://github.com/typelevel/natchez')});</script>
 
 
 </html>

--- a/reference/index.html
+++ b/reference/index.html
@@ -6,7 +6,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content='docs'/>
-<link rel="canonical" href="https://github.com/tpolecat/natchezreference/index.html"/>
+<link rel="canonical" href="https://github.com/typelevel/natchezreference/index.html"/>
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="../lib/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="../js/page.js"></script>
@@ -32,7 +32,7 @@
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -58,6 +58,7 @@
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -95,7 +96,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -121,6 +122,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -185,10 +187,10 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <script type="text/javascript" src="../js/link_fix.js"></script>
 
 <div class="source-github">
-The source code for this page can be found <a id="source-link" href="https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/reference/index.md">here</a>.
+The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/reference/index.md">here</a>.
 </div>
 
-<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/reference/index.md')});</script>
+<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/reference/index.md')});</script>
 
 <div class="nav-next">
 <p><strong>Next:</strong> <a href="../reference/entrypoints.html">Entry Points</a></p>
@@ -232,7 +234,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2021</span>
+<span class="text">&copy; 2025</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->
@@ -257,7 +259,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 <script type="text/javascript" src="../lib/prettify/prettify.js"></script>
 <script type="text/javascript" src="../lib/prettify/lang-scala.js"></script>
 <script type="text/javascript">jQuery(function(){window.prettyPrint && prettyPrint()});</script>
-<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.1.5', 'https://github.com/tpolecat/natchez')});</script>
+<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.3.7', 'https://github.com/typelevel/natchez')});</script>
 
 
 </html>

--- a/reference/kernels.html
+++ b/reference/kernels.html
@@ -6,7 +6,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content='docs'/>
-<link rel="canonical" href="https://github.com/tpolecat/natchezreference/kernels.html"/>
+<link rel="canonical" href="https://github.com/typelevel/natchezreference/kernels.html"/>
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="../lib/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="../js/page.js"></script>
@@ -32,7 +32,7 @@
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -58,6 +58,7 @@
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -95,7 +96,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -121,6 +122,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -164,7 +166,6 @@ import org.http4s.{ EntityDecoder, Uri, Header }
 import org.http4s.Method.GET
 import org.http4s.client.Client
 import org.http4s.client.dsl.io._
-import org.typelevel.ci.CIString
 </code></pre>
 <p>We can add a <code>Span</code>&rsquo;s kernel to an outgoing <code>Client</code> request. If the remote server supports tracing via the same back end, it can extend the trace with child spans.</p>
 <pre class="prettyprint"><code class="language-scala">def makeRequest[A](span: Span[IO], client: Client[IO], uri: Uri)(
@@ -172,7 +173,7 @@ import org.typelevel.ci.CIString
 ): IO[A] =
   span.kernel.flatMap { k =&gt;
     // turn a Map[String, String] into List[Header]
-    val http4sHeaders = k.toHeaders.map { case (k, v) =&gt; Header.Raw(CIString(k), v) } .toSeq
+    val http4sHeaders = k.toHeaders.map { case (k, v) =&gt; Header.Raw(k, v) } .toSeq
     client.expect[A](GET(uri).withHeaders(http4sHeaders))
   }
 </code></pre><div class="callout note "><div class="callout-title">Note</div>
@@ -180,10 +181,10 @@ import org.typelevel.ci.CIString
 <script type="text/javascript" src="../js/link_fix.js"></script>
 
 <div class="source-github">
-The source code for this page can be found <a id="source-link" href="https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/reference/kernels.md">here</a>.
+The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/reference/kernels.md">here</a>.
 </div>
 
-<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/reference/kernels.md')});</script>
+<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/reference/kernels.md')});</script>
 
 <div class="nav-next">
 <p><strong>Next:</strong> <a href="../reference/spans.html">Spans</a></p>
@@ -241,7 +242,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2021</span>
+<span class="text">&copy; 2025</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->
@@ -266,7 +267,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 <script type="text/javascript" src="../lib/prettify/prettify.js"></script>
 <script type="text/javascript" src="../lib/prettify/lang-scala.js"></script>
 <script type="text/javascript">jQuery(function(){window.prettyPrint && prettyPrint()});</script>
-<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.1.5', 'https://github.com/tpolecat/natchez')});</script>
+<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.3.7', 'https://github.com/typelevel/natchez')});</script>
 
 
 </html>

--- a/reference/spans.html
+++ b/reference/spans.html
@@ -6,7 +6,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content='docs'/>
-<link rel="canonical" href="https://github.com/tpolecat/natchezreference/spans.html"/>
+<link rel="canonical" href="https://github.com/typelevel/natchezreference/spans.html"/>
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="../lib/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="../js/page.js"></script>
@@ -32,7 +32,7 @@
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -58,6 +58,7 @@
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -95,7 +96,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -121,6 +122,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -180,7 +182,7 @@ import natchez.{ Span, Trace }
 <p>This approach might make sense if you&rsquo;re using a concrete effect type with no &ldquo;reader&rdquo; capability (like <code>IO</code> with Cats-Effect 2).</p>
 <h3><a href="#ambient-span" name="ambient-span" class="anchor"><span class="anchor-link"></span></a>Ambient Span</h3>
 <p>A nicer way to pass the current span around is to use the <code>Trace</code> constraint, which ensures that there is always a current span. With this strategy you never have see <code>Span</code> reference at all, but instead use the <code>Trace</code> instance directly.</p>
-<pre class="prettyprint"><code class="language-scala">def wibble[F[_]: Trace: Monad](name: String, age: Int, parent: Span[F]): F[Unit] =
+<pre class="prettyprint"><code class="language-scala">def wibble[F[_]: Trace: Monad](name: String, age: Int): F[Unit] =
   Trace[F].span(&quot;wibble&quot;) {
     for {
       _ &lt;- Trace[F].put(&quot;name&quot; -&gt; name, &quot;age&quot; -&gt; age)
@@ -239,10 +241,10 @@ import natchez.{ Span, Trace }
 <script type="text/javascript" src="../js/link_fix.js"></script>
 
 <div class="source-github">
-The source code for this page can be found <a id="source-link" href="https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/reference/spans.md">here</a>.
+The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/reference/spans.md">here</a>.
 </div>
 
-<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/reference/spans.md')});</script>
+<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/reference/spans.md')});</script>
 
 <div class="nav-next">
 <p><strong>Next:</strong> <a href="../reference/trace.html">Trace Constraint</a></p>
@@ -302,7 +304,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2021</span>
+<span class="text">&copy; 2025</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->
@@ -327,7 +329,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 <script type="text/javascript" src="../lib/prettify/prettify.js"></script>
 <script type="text/javascript" src="../lib/prettify/lang-scala.js"></script>
 <script type="text/javascript">jQuery(function(){window.prettyPrint && prettyPrint()});</script>
-<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.1.5', 'https://github.com/tpolecat/natchez')});</script>
+<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.3.7', 'https://github.com/typelevel/natchez')});</script>
 
 
 </html>

--- a/reference/trace.html
+++ b/reference/trace.html
@@ -6,7 +6,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content='docs'/>
-<link rel="canonical" href="https://github.com/tpolecat/natchezreference/trace.html"/>
+<link rel="canonical" href="https://github.com/typelevel/natchezreference/trace.html"/>
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="../lib/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="../js/page.js"></script>
@@ -32,7 +32,7 @@
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -58,6 +58,7 @@
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -95,7 +96,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -121,6 +122,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -208,15 +210,31 @@ def go[F[_]](span: Span[F])(
 </code></pre>
 <p>This is more general than the <code>Kleisli</code> instance above and allows you to instantiate <code>F</code> as <code>RWST</code> for example, at the cost of an additional dependency.</p>
 <h2><a href="#cats-effect-3-io-instance" name="cats-effect-3-io-instance" class="anchor"><span class="anchor-link"></span></a>Cats-Effect 3 IO Instance</h2>
-<p>Given a <code>Span[F]</code> you can construct a <code>Trace[IO]</code> for <strong>Cats-Effect 3</strong> (for Cats-Effect 2 you will need to use <code>Kleisli</code> or <code>Local</code> above). This uses <code>FiberLocal</code> to pass the span around.</p>
-<p>TODO: Example</p>
+<p>Given an <code>EntryPoint[IO]</code> you can construct a <code>Trace[IO]</code> for <strong>Cats-Effect 3</strong>. This will create a root span for each requested child span.</p>
+<pre class="prettyprint"><code class="language-scala">import cats.effect.IO
+import natchez.EntryPoint
+
+def goIO(ep: EntryPoint[IO]): IO[Unit] =
+  Trace.ioTraceForEntryPoint(ep).flatMap { implicit trace =&gt;
+    wibble[IO](&quot;bob&quot;, 42)
+  }
+</code></pre>
+<p>Alternatively, a <code>Trace[IO]</code> can be constructed from a <code>Span[IO]</code> directly.</p>
+<pre class="prettyprint"><code class="language-scala">import cats.effect.IO
+
+def goIO(span: Span[IO]): IO[Unit] =
+  Trace.ioTrace(span).flatMap { implicit trace =&gt;
+    wibble[IO](&quot;bob&quot;, 42)
+  }
+</code></pre>
+<p>Both methods use <code>IOLocal</code> to pass the span around. For Cats-Effect 2 you will need to use <code>Kleisli</code> or <code>Local</code> as described above.</p>
 <script type="text/javascript" src="../js/link_fix.js"></script>
 
 <div class="source-github">
-The source code for this page can be found <a id="source-link" href="https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/reference/trace.md">here</a>.
+The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/reference/trace.md">here</a>.
 </div>
 
-<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/reference/trace.md')});</script>
+<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/reference/trace.md')});</script>
 
 <div class="nav-next">
 <p><strong>Next:</strong> <a href="../reference/tracevalues.html">Trace Values</a></p>
@@ -276,7 +294,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2021</span>
+<span class="text">&copy; 2025</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->
@@ -301,7 +319,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 <script type="text/javascript" src="../lib/prettify/prettify.js"></script>
 <script type="text/javascript" src="../lib/prettify/lang-scala.js"></script>
 <script type="text/javascript">jQuery(function(){window.prettyPrint && prettyPrint()});</script>
-<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.1.5', 'https://github.com/tpolecat/natchez')});</script>
+<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.3.7', 'https://github.com/typelevel/natchez')});</script>
 
 
 </html>

--- a/reference/tracevalues.html
+++ b/reference/tracevalues.html
@@ -6,7 +6,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="description" content='docs'/>
-<link rel="canonical" href="https://github.com/tpolecat/natchezreference/tracevalues.html"/>
+<link rel="canonical" href="https://github.com/typelevel/natchezreference/tracevalues.html"/>
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <script type="text/javascript" src="../lib/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="../js/page.js"></script>
@@ -32,7 +32,7 @@
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -58,6 +58,7 @@
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -95,7 +96,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <span class="home-icon">⌂</span>Natchez
 </a>
 <div class="version-number">
-0.1.5
+0.3.7
 </div>
 </div>
 <div class="nav-toc">
@@ -121,6 +122,7 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
     <li><a href="../backends/noop.html" class="page">No-Op</a></li>
     <li><a href="../backends/odin.html" class="page">Odin</a></li>
     <li><a href="../backends/opencensus.html" class="page">OpenCensus</a></li>
+    <li><a href="../backends/opentelemetry.html" class="page">OpenTelemetry</a></li>
   </ul></li>
   <li><a href="../examples/index.html" class="page">Examples</a>
   <ul>
@@ -164,10 +166,10 @@ C16.952,7,17,6.553,17,6c0-0.553-0.048-1-0.6-1H3.6C3.048,5,3,5.447,3,6C3,6.553,3.
 <script type="text/javascript" src="../js/link_fix.js"></script>
 
 <div class="source-github">
-The source code for this page can be found <a id="source-link" href="https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/reference/tracevalues.md">here</a>.
+The source code for this page can be found <a id="source-link" href="https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/reference/tracevalues.md">here</a>.
 </div>
 
-<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/tpolecat/natchez/tree/v0.1.5/modules/docs/target/mdoc/reference/tracevalues.md')});</script>
+<script type="text/javascript">jQuery(function(){sourceUrlFix('https://github.com/typelevel/natchez/tree/master/modules/docs/target/mdoc/reference/tracevalues.md')});</script>
 
 <div class="nav-next">
 <p><strong>Next:</strong> <a href="../backends/index.html">Back Ends</a></p>
@@ -211,7 +213,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 
 <!--
 <div class="copyright">
-<span class="text">&copy; 2021</span>
+<span class="text">&copy; 2025</span>
 <a href="https://www.example.com" class="logo">logo</a>
 </div>
 -->
@@ -236,7 +238,7 @@ The source code for this page can be found <a id="source-link" href="https://git
 <script type="text/javascript" src="../lib/prettify/prettify.js"></script>
 <script type="text/javascript" src="../lib/prettify/lang-scala.js"></script>
 <script type="text/javascript">jQuery(function(){window.prettyPrint && prettyPrint()});</script>
-<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.1.5', 'https://github.com/tpolecat/natchez')});</script>
+<script type="text/javascript">jQuery(function(jq){initOldVersionWarnings(jq, '0.3.7', 'https://github.com/typelevel/natchez')});</script>
 
 
 </html>


### PR DESCRIPTION
I've regenerated the site manually using the latest version from main as it hasn't been updated in 4 years.

The only thing that doesn't work is the links to edit docs source files, which I can't quite figure out how to set up correctly in paradox, but they currently don't work anyway, so this is still an improvement over the existing version.

Would it make sense to move this site to `sbt-typelevel-site` and automate the deployments?