### PR TITLE
Ignore active span when creating root span with DataDog

### DIFF
--- a/modules/datadog/src/main/scala/DDEntryPoint.scala
+++ b/modules/datadog/src/main/scala/DDEntryPoint.scala
@@ -18,7 +18,7 @@ final class DDEntryPoint[F[_]: Sync](tracer: ot.Tracer, uriPrefix: Option[URI])
   override def root(name: String, options: Span.Options): Resource[F, Span[F]] = {
     def initSpan(): F[ot.Span] =
       Sync[F]
-        .delay(tracer.buildSpan(name))
+        .delay(tracer.buildSpan(name).ignoreActiveSpan())
         .flatTap(addSpanKind(_, options.spanKind))
         .flatMap(options.links.foldM(_)(addLink[F](tracer)))
         .flatMap(builder => Sync[F].delay(builder.start()))


### PR DESCRIPTION
Root spans should not have parents. New spans automatically become children of active span if no other reference is added unless active span is explicitly ignored.