### PR TITLE
Activate child spans just like root spans

### DIFF
--- a/modules/datadog/src/main/scala/DDSpan.scala
+++ b/modules/datadog/src/main/scala/DDSpan.scala
@@ -74,6 +74,9 @@ final case class DDSpan[F[_]: Sync](
           case (span, ExitCase.Errored(e)) => Sync[F].delay(span.log(e.toString).finish())
           case (span, _)                   => Sync[F].delay(span.finish())
         }
+        .flatTap(span =>
+          Resource.make(Sync[F].delay(tracer.activateSpan(span)))(s => Sync[F].delay(s.close()))
+        )
         .map(DDSpan(tracer, _, uriPrefix, options))
     )
 


### PR DESCRIPTION
`DDEntryPoint` activates created spans so `DDSpan` should too.

Activation binds span to current thread via ThreadLocal so it will become incorrect when IO/Fiber switches threads but at least it's an improvement and consistent with root spans.

Ideally there would be a Span option to disable activation entirely like this: https://github.com/typelevel/natchez/pull/1187