### PR TITLE
Do not activate span since thread-local propagation does not work correctly when using cats-effect

### DIFF
--- a/modules/datadog/src/main/scala/DDEntryPoint.scala
+++ b/modules/datadog/src/main/scala/DDEntryPoint.scala
@@ -25,9 +25,6 @@ final class DDEntryPoint[F[_]: Sync](tracer: ot.Tracer, uriPrefix: Option[URI])
 
     Resource
       .make(initSpan())(s => Sync[F].delay(s.finish()))
-      .flatTap(span =>
-        Resource.make(Sync[F].delay(tracer.activateSpan(span)))(s => Sync[F].delay(s.close()))
-      )
       .map(DDSpan(tracer, _, uriPrefix, options))
   }
 
@@ -51,9 +48,6 @@ final class DDEntryPoint[F[_]: Sync](tracer: ot.Tracer, uriPrefix: Option[URI])
 
     Resource
       .make(initSpan())(s => Sync[F].delay(s.finish()))
-      .flatTap(span =>
-        Resource.make(Sync[F].delay(tracer.activateSpan(span)))(s => Sync[F].delay(s.close()))
-      )
       .map(DDSpan(tracer, _, uriPrefix, options))
   }
 


### PR DESCRIPTION
As mentioned in https://github.com/typelevel/natchez/pull/1186#issuecomment-3020004700 we should not be activating spans on thread local by default. This is incorrect when using `IO`.

The only safe way to do this is explicitly as in https://github.com/typelevel/natchez/pull/1189.

Not activating spans is also consistent with other backends like OpenTelemetry.