### PR TITLE
OpenTelemetry module should record canceled spans as errors

### DIFF
--- a/modules/opentelemetry/src/main/scala/natchez/opentelemetry/OpenTelemetrySpan.scala
+++ b/modules/opentelemetry/src/main/scala/natchez/opentelemetry/OpenTelemetrySpan.scala
@@ -146,7 +146,7 @@ private[opentelemetry] object OpenTelemetrySpan {
       _ <- Sync[F].delay {
         exitCase match {
           case Succeeded   => outer.span.setStatus(StatusCode.OK)
-          case Canceled    => outer.span.setStatus(StatusCode.UNSET)
+          case Canceled    => outer.span.setStatus(StatusCode.ERROR, "Canceled")
           case Errored(ex) =>
             outer.span.setStatus(StatusCode.ERROR, ex.getMessage)
             outer.span.recordException(ex)


### PR DESCRIPTION
I think it's misleading to record canceled spans using `StatusCode.UNSET`. [The spec says](https://opentelemetry.io/docs/concepts/signals/traces/#span-status) 
> The default value is Unset. A span status that is Unset means that the operation it tracked successfully completed without an error.

but a canceled span did not successfully complete. There's no canceled status in the spec, so I think `StatusCode.ERROR` is the more appropriate choice.

This came up as I was looking at some trace data this afternoon and initially thought a bunch of parallel operations succeeded, with only one failure. Only after more investigation did I realize that the failure actually resulted in the other operations being canceled; none of them actually completed successfully. This would have been immediately obvious if the canceled operations had the Error status set.